### PR TITLE
mesh vs polygon selection modes

### DIFF
--- a/src/components/scene/GuiPanel.tsx
+++ b/src/components/scene/GuiPanel.tsx
@@ -79,6 +79,7 @@ const StyledDrawer = styled(Drawer)(
 
     & > .MuiPaper-root .MuiToggleButtonGroup-root .MuiButtonBase-root {
       width: 100%;
+      justify-content: center;
     }
 
     & > .MuiPaper-root > .MuiTypography-subtitle2, & > .MuiPaper-root > :not(.MuiDivider-root) {
@@ -172,7 +173,7 @@ export default function GuiPanel() {
     (_: React.MouseEvent<HTMLElement>, type: 'mesh' | 'polygon') => {
       type && dispatch(setObjectType(type));
     },
-    []
+    [objectSelectionType]
   );
 
   const onSetMeshDisplayMode = useCallback(
@@ -298,9 +299,9 @@ export default function GuiPanel() {
               exclusive
               onChange={onSetObjectSelectionType}
               aria-label='text alignment'
-              disabled
             >
               <ToggleButton value='mesh'>mesh</ToggleButton>
+              <ToggleButton value='polygon'>polygon</ToggleButton>
             </ToggleButtonGroup>
           </Grid>
         </Grid>

--- a/src/components/scene/GuiPanel.tsx
+++ b/src/components/scene/GuiPanel.tsx
@@ -279,12 +279,12 @@ export default function GuiPanel() {
           </Grid>
           <Grid xs={8}>
             <Typography variant='body1' textAlign='right'>
-              Object Index
+              Object Key
             </Typography>
           </Grid>
           <Grid xs={4}>
             <Typography variant='button' textAlign='right'>
-              {objectKey ? 'N/A' : objectKey}
+              {!objectKey ? 'N/A' : objectKey}
             </Typography>
           </Grid>
           <Grid xs={8}>

--- a/src/components/scene/GuiPanel.tsx
+++ b/src/components/scene/GuiPanel.tsx
@@ -5,7 +5,8 @@ import {
   selectModel,
   selectModelCount,
   selectModelIndex,
-  selectObjectIndex,
+  selectObjectKey,
+  selectObjectMeshIndex,
   selectObjectSelectionType,
   selectTextureDefs,
   setObjectType,
@@ -155,7 +156,8 @@ export default function GuiPanel() {
   }, [dispatch]);
   const modelIndex = useAppSelector(selectModelIndex);
   const modelCount = useAppSelector(selectModelCount);
-  const objectIndex = useAppSelector(selectObjectIndex);
+  const objectKey = useAppSelector(selectObjectKey);
+  const meshIndex = useAppSelector(selectObjectMeshIndex);
   const objectSelectionType = useAppSelector(selectObjectSelectionType);
   const model = useAppSelector(selectModel);
   const textureDefs = useAppSelector(selectTextureDefs);
@@ -164,10 +166,10 @@ export default function GuiPanel() {
   );
 
   const selectedMeshTexture: number = useMemo(() => {
-    const textureIndex = model?.meshes?.[objectIndex]?.textureIndex;
+    const textureIndex = model?.meshes?.[meshIndex]?.textureIndex;
 
     return typeof textureIndex === 'number' ? textureIndex : -1;
-  }, [model, objectIndex]);
+  }, [model, objectKey, meshIndex]);
 
   const onSetObjectSelectionType = useCallback(
     (_: React.MouseEvent<HTMLElement>, type: 'mesh' | 'polygon') => {
@@ -282,7 +284,7 @@ export default function GuiPanel() {
           </Grid>
           <Grid xs={4}>
             <Typography variant='button' textAlign='right'>
-              {objectIndex === -1 ? 'N/A' : objectIndex}
+              {objectKey ? 'N/A' : objectKey}
             </Typography>
           </Grid>
           <Grid xs={8}>
@@ -326,7 +328,7 @@ export default function GuiPanel() {
                 </p>
                 <p>
                   ⚠️ Note that this feature is WIP. There are known issues with
-                  vertex ordering ⚠️
+                  winding index order on vertices ⚠️
                 </p>
               </div>
             }

--- a/src/components/scene/RenderedMesh.tsx
+++ b/src/components/scene/RenderedMesh.tsx
@@ -1,23 +1,24 @@
-import { ThreeEvent } from '@react-three/fiber';
 import RenderedPolygon from './RenderedPolygon';
 import { NLTextureDef } from '@/types/NLAbstractions';
 import { useTexture } from '@react-three/drei';
 import { ClampToEdgeWrapping, RepeatWrapping } from 'three';
 
 type RenderedMeshProps = {
-  index: number;
-  objectIndex: number;
-  onSelectObjectIndex: (index: number) => void;
+  objectKey: string;
+  selectedObjectKey?: string;
+  objectSelectionType: 'mesh' | 'polygon';
+  onSelectObjectKey: (key: string) => void;
   textureDefs: NLTextureDef[];
 } & NLMesh;
 
 const transparent1x1 = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==`;
 
 export default function RenderedMesh({
-  index,
+  objectKey,
   polygons,
-  objectIndex,
-  onSelectObjectIndex,
+  selectedObjectKey,
+  onSelectObjectKey,
+  objectSelectionType,
   textureWrappingFlags,
   textureIndex,
   textureDefs,
@@ -36,24 +37,21 @@ export default function RenderedMesh({
     ? RepeatWrapping
     : ClampToEdgeWrapping;
 
-  const isSelected = index === objectIndex;
-
-  const handleClick = (e: ThreeEvent<MouseEvent>) => {
-    e.stopPropagation();
-    onSelectObjectIndex(objectIndex !== index ? index : -1);
-  };
-
   return (
-    <group onClick={handleClick}>
-      {polygons.map((p, pIndex) => (
-        <RenderedPolygon
-          {...p}
-          isSelected={isSelected}
-          key={pIndex}
-          index={pIndex}
-          texture={texture}
-        />
-      ))}
+    <group>
+      {polygons.map((p, pIndex) => {
+        const key = `${objectKey}-${pIndex}`;
+        return (
+          <RenderedPolygon
+            {...p}
+            key={key}
+            objectKey={objectSelectionType === 'mesh' ? objectKey : key}
+            selectedObjectKey={selectedObjectKey}
+            onSelectObjectKey={onSelectObjectKey}
+            texture={texture}
+          />
+        );
+      })}
     </group>
   );
 }

--- a/src/components/scene/RenderedPolygon.tsx
+++ b/src/components/scene/RenderedPolygon.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo, useRef } from 'react';
 import { Text } from '@react-three/drei';
 import { DoubleSide, Mesh, MeshBasicMaterial, Texture, Vector3 } from 'three';
-import { useFrame } from '@react-three/fiber';
+import { ThreeEvent, useFrame } from '@react-three/fiber';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import { useTheme } from '@mui/material';
 
@@ -11,12 +11,14 @@ export default function RenderedPolygon({
   vertexGroupMode,
   vertexes,
   address,
-  isSelected,
-  index,
+  objectKey,
+  selectedObjectKey,
+  onSelectObjectKey,
   texture
 }: NLPolygon & {
-  isSelected: boolean;
-  index: number;
+  objectKey: string;
+  selectedObjectKey?: string;
+  onSelectObjectKey: (key: string) => void;
   texture?: Texture;
 }) {
   const { meshDisplayMode, showPolygonAddresses } =
@@ -26,6 +28,8 @@ export default function RenderedPolygon({
 
   const { sceneMesh: colors } = theme.palette;
   let color: React.CSSProperties['color'];
+
+  const isSelected = objectKey === selectedObjectKey;
 
   if (meshDisplayMode === 'wireframe') {
     color = isSelected ? colors.selected : colors.default;
@@ -116,15 +120,23 @@ export default function RenderedPolygon({
         ref={textRef}
         material={material}
       >
-        [{index}] {`0x${address.toString(16)}`}
+        [{objectKey}] {`0x${address.toString(16)}`}
       </Text>
     );
   }, [color, showPolygonAddresses, meshDisplayMode, isSelected]);
 
+  const handleClick = (e: ThreeEvent<MouseEvent>) => {
+    e.stopPropagation();
+    onSelectObjectKey(objectKey);
+  };
+
   return (
     <>
       {meshAddressText}
-      <mesh key={`${address}_${meshDisplayMode}_${color}`}>
+      <mesh
+        key={`${address}_${meshDisplayMode}_${color}`}
+        onClick={handleClick}
+      >
         <meshBasicMaterial color={color} {...meshModeMaterialProps} />
         <bufferGeometry attach={'geometry'}>
           <bufferAttribute

--- a/src/components/scene/RenderedPolygon.tsx
+++ b/src/components/scene/RenderedPolygon.tsx
@@ -126,6 +126,7 @@ export default function RenderedPolygon({
   }, [color, showPolygonAddresses, meshDisplayMode, isSelected]);
 
   const handleClick = (e: ThreeEvent<MouseEvent>) => {
+    e.nativeEvent.stopPropagation();
     e.stopPropagation();
     onSelectObjectKey(objectKey);
   };

--- a/src/components/scene/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas.tsx
@@ -1,22 +1,34 @@
 import { useCallback, useContext, useMemo } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from '@react-three/drei';
-import { Canvas } from '@react-three/fiber';
+import { Canvas, ThreeEvent } from '@react-three/fiber';
 import {
   selectModel,
   selectObjectKey,
   selectObjectSelectionType
 } from '@/store/selectors';
-import { useAppSelector, useAppDispatch, setObjectIndex } from '@/store';
+import { useAppSelector, useAppDispatch, setObjectKey } from '@/store';
 import RenderedMesh from './RenderedMesh';
 import { useSceneKeyboardActions } from '@/hooks';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
-import { useTheme } from '@mui/material';
+import { styled, useTheme } from '@mui/material';
 import { SceneContextSetup } from '@/contexts/SceneContext';
 
 THREE.ColorManagement.enabled = true;
 
 const cameraParams = { far: 5000000 };
+
+const Styled = styled('div')(
+  () => `
+  & {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    zIndex: -1;
+  }
+`
+);
 
 export default function SceneCanvas() {
   useSceneKeyboardActions();
@@ -28,9 +40,7 @@ export default function SceneCanvas() {
   const objectSelectionType = useAppSelector(selectObjectSelectionType);
   const onSelectObjectKey = useCallback(
     (key: string) => {
-      if (objectKey !== key) {
-        dispatch(setObjectIndex(key));
-      }
+      dispatch(setObjectKey(objectKey !== key ? key : undefined));
     },
     [objectKey]
   );
@@ -48,23 +58,25 @@ export default function SceneCanvas() {
   );
 
   return (
-    <Canvas camera={cameraParams} frameloop='demand' style={canvasStyle}>
-      <SceneContextSetup />
-      <group dispose={null}>
-        {!viewOptions.showAxesHelper ? undefined : <axesHelper args={[50]} />}
-        {(model?.meshes || []).map((m, i) => (
-          <RenderedMesh
-            key={m.address}
-            {...m}
-            objectKey={`${i}`}
-            selectedObjectKey={objectKey}
-            objectSelectionType={objectSelectionType}
-            onSelectObjectKey={onSelectObjectKey}
-            textureDefs={textureDefs}
-          />
-        ))}
-        <OrbitControls />
-      </group>
-    </Canvas>
+    <Styled>
+      <Canvas camera={cameraParams} frameloop='demand' style={canvasStyle}>
+        <SceneContextSetup />
+        <group dispose={null}>
+          {!viewOptions.showAxesHelper ? undefined : <axesHelper args={[50]} />}
+          {(model?.meshes || []).map((m, i) => (
+            <RenderedMesh
+              key={m.address}
+              {...m}
+              objectKey={`${i}`}
+              selectedObjectKey={objectKey}
+              objectSelectionType={objectSelectionType}
+              onSelectObjectKey={onSelectObjectKey}
+              textureDefs={textureDefs}
+            />
+          ))}
+          <OrbitControls />
+        </group>
+      </Canvas>
+    </Styled>
   );
 }

--- a/src/components/scene/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas.tsx
@@ -2,7 +2,11 @@ import { useCallback, useContext, useMemo } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
-import { selectModel, selectObjectIndex } from '@/store/selectors';
+import {
+  selectModel,
+  selectObjectKey,
+  selectObjectSelectionType
+} from '@/store/selectors';
 import { useAppSelector, useAppDispatch, setObjectIndex } from '@/store';
 import RenderedMesh from './RenderedMesh';
 import { useSceneKeyboardActions } from '@/hooks';
@@ -20,14 +24,15 @@ export default function SceneCanvas() {
   const viewOptions = useContext(ViewOptionsContext);
 
   const dispatch = useAppDispatch();
-  const objectIndex = useAppSelector(selectObjectIndex);
-  const onSelectObjectIndex = useCallback(
-    (i: number) => {
-      if (objectIndex !== i) {
-        dispatch(setObjectIndex(i));
+  const objectKey = useAppSelector(selectObjectKey);
+  const objectSelectionType = useAppSelector(selectObjectSelectionType);
+  const onSelectObjectKey = useCallback(
+    (key: string) => {
+      if (objectKey !== key) {
+        dispatch(setObjectIndex(key));
       }
     },
-    [objectIndex]
+    [objectKey]
   );
 
   const textureDefs = useAppSelector((s) => s.stageData.textureDefs);
@@ -50,10 +55,11 @@ export default function SceneCanvas() {
         {(model?.meshes || []).map((m, i) => (
           <RenderedMesh
             key={m.address}
-            index={i}
             {...m}
-            objectIndex={objectIndex}
-            onSelectObjectIndex={onSelectObjectIndex}
+            objectKey={`${i}`}
+            selectedObjectKey={objectKey}
+            objectSelectionType={objectSelectionType}
+            onSelectObjectKey={onSelectObjectKey}
             textureDefs={textureDefs}
           />
         ))}

--- a/src/hooks/useModelSelectionExport.ts
+++ b/src/hooks/useModelSelectionExport.ts
@@ -1,29 +1,44 @@
 import { useCallback, useMemo } from 'react';
 import exportFromJSON from 'export-from-json';
-import { selectModel, selectModelIndex, selectObjectKey } from '@/store';
-import { useSelector } from 'react-redux';
+import {
+  selectModel,
+  selectModelIndex,
+  selectObjectKey,
+  selectObjectSelectionType,
+  useAppSelector
+} from '@/store';
 
 export default function useModelSelectionExport() {
-  const model = useSelector(selectModel);
-  const modelIndex = useSelector(selectModelIndex);
-  const objectKey = useSelector(selectObjectKey);
+  const model = useAppSelector(selectModel);
+  const modelIndex = useAppSelector(selectModelIndex);
+  const objectKey = useAppSelector(selectObjectKey);
+  const objectType = useAppSelector(selectObjectSelectionType);
 
   const data = useMemo(() => {
     if (!model) {
       return {};
     }
-    if (objectKey === -1) {
+    if (objectKey === undefined) {
       return model;
     }
 
-    return model.meshes[objectKey];
-  }, [model, objectKey]);
+    if (objectType === 'mesh') {
+      return model.meshes[Number(objectKey)];
+    }
+
+    // type === 'polygon'
+    const [meshKey, polygonKey] = objectKey.split('-').map(Number) as [
+      number,
+      number
+    ];
+    return model.meshes[Number(meshKey)].polygons[Number(polygonKey)];
+  }, [model, objectKey, objectType]);
 
   const onDownloadModelSelection = useCallback(() => {
     if (modelIndex === -1) {
       return;
     }
-    const hasSelection = objectKey !== -1;
+    const hasSelection = objectKey !== undefined;
     exportFromJSON({
       data,
       fileName: `model-${modelIndex}${!hasSelection ? '' : `-${objectKey}`}`,

--- a/src/hooks/useModelSelectionExport.ts
+++ b/src/hooks/useModelSelectionExport.ts
@@ -1,35 +1,35 @@
 import { useCallback, useMemo } from 'react';
 import exportFromJSON from 'export-from-json';
-import { selectModel, selectModelIndex, selectObjectIndex } from '@/store';
+import { selectModel, selectModelIndex, selectObjectKey } from '@/store';
 import { useSelector } from 'react-redux';
 
 export default function useModelSelectionExport() {
   const model = useSelector(selectModel);
   const modelIndex = useSelector(selectModelIndex);
-  const objectIndex = useSelector(selectObjectIndex);
+  const objectKey = useSelector(selectObjectKey);
 
   const data = useMemo(() => {
     if (!model) {
       return {};
     }
-    if (objectIndex === -1) {
+    if (objectKey === -1) {
       return model;
     }
 
-    return model.meshes[objectIndex];
-  }, [model, objectIndex]);
+    return model.meshes[objectKey];
+  }, [model, objectKey]);
 
   const onDownloadModelSelection = useCallback(() => {
     if (modelIndex === -1) {
       return;
     }
-    const hasSelection = objectIndex !== -1;
+    const hasSelection = objectKey !== -1;
     exportFromJSON({
       data,
-      fileName: `model-${modelIndex}${!hasSelection ? '' : `-${objectIndex}`}`,
+      fileName: `model-${modelIndex}${!hasSelection ? '' : `-${objectKey}`}`,
       exportType: exportFromJSON.types.json
     });
-  }, [modelIndex, objectIndex, data]);
+  }, [modelIndex, objectKey, data]);
 
   return onDownloadModelSelection;
 }

--- a/src/store/modelViewerSlice.ts
+++ b/src/store/modelViewerSlice.ts
@@ -5,14 +5,14 @@ import { AppState } from './store';
 
 export interface ModelViewerState {
   modelIndex: number;
-  objectIndex: number;
+  objectKey?: string;
   objectSelectionType: 'mesh' | 'polygon';
   meshDisplayMode: 'wireframe' | 'textured';
 }
 
 export const initialModelViewerState: ModelViewerState = {
   modelIndex: 0,
-  objectIndex: -1,
+  objectKey: undefined,
   objectSelectionType: 'mesh',
   meshDisplayMode: 'textured'
 };
@@ -42,17 +42,17 @@ const modelViewerSlice = createSlice({
     setModelViewedIndex(state, { payload: modelIndex }: { payload: number }) {
       Object.assign(state, {
         modelIndex,
-        objectIndex: -1
+        objectKey: undefined
       });
     },
 
-    setObjectIndex(state, { payload: objectIndex }) {
-      Object.assign(state, { objectIndex });
+    setObjectIndex(state, { payload: objectKey }) {
+      Object.assign(state, { objectKey });
     },
 
     setObjectType(state, { payload: objectSelectionType }) {
       Object.assign(state, {
-        objectIndex: -1,
+        objectKey: undefined,
         objectSelectionType
       });
     }
@@ -64,7 +64,7 @@ const modelViewerSlice = createSlice({
     builder.addCase(loadStagePolygonFile.fulfilled, (state) => {
       Object.assign(state, {
         modelIndex: 0,
-        objectIndex: -1
+        objectKey: undefined
       });
     });
   }

--- a/src/store/modelViewerSlice.ts
+++ b/src/store/modelViewerSlice.ts
@@ -46,7 +46,7 @@ const modelViewerSlice = createSlice({
       });
     },
 
-    setObjectIndex(state, { payload: objectKey }) {
+    setObjectKey(state, { payload: objectKey }) {
       Object.assign(state, { objectKey });
     },
 
@@ -70,6 +70,6 @@ const modelViewerSlice = createSlice({
   }
 });
 
-export const { setObjectIndex, setObjectType } = modelViewerSlice.actions;
+export const { setObjectKey, setObjectType } = modelViewerSlice.actions;
 
 export default modelViewerSlice;

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -3,7 +3,7 @@ import { AppState } from './store';
 
 export const selectModelIndex = (s: AppState) => s.modelViewer.modelIndex;
 
-export const selectObjectIndex = (s: AppState) => s.modelViewer.objectIndex;
+export const selectObjectKey = (s: AppState) => s.modelViewer.objectKey;
 
 export const selectStageModels = (s: AppState) => s.stageData.models;
 
@@ -25,7 +25,12 @@ export const selectTextureDefs = (s: AppState) => s.stageData.textureDefs;
 export const selectModel = createSelector(
   selectModelIndex,
   selectStageModels,
-  (modelIndex, models) => {
-    return models?.[modelIndex];
-  }
+  (modelIndex, models) => models?.[modelIndex]
+);
+
+/** infers mesh selection from selected object key */
+export const selectObjectMeshIndex = createSelector(
+  selectObjectKey,
+  (objectKey: string | undefined) =>
+    !objectKey ? -1 : Number(objectKey.split('-')[0])
 );


### PR DESCRIPTION
Using object keys vs strict selection indexes. Things introduced in these changes will help with multiple selection of objects and troubleshooting blender .obj export by letting me narrow down indices to individual polygons.
![image](https://github.com/rob2d/modnao/assets/1799905/25560d9d-fee0-4016-95c7-31f1f6d68cb4)
