### PR TITLE
refactor view options, add line thickness option

### DIFF
--- a/src/components/scene/GuiPanel.tsx
+++ b/src/components/scene/GuiPanel.tsx
@@ -185,25 +185,25 @@ export default function GuiPanel() {
     [viewOptions.setMeshDisplayMode]
   );
 
-  const onSetShowAxesHelper = useCallback(
+  const onSetAxesHelperVisible = useCallback(
     (_: SyntheticEvent<Element, Event>, value: boolean) => {
-      viewOptions.setShowAxesHelper(value);
+      viewOptions.setAxesHelperVisible(value);
     },
-    [viewOptions.setShowAxesHelper]
+    [viewOptions.setAxesHelperVisible]
   );
 
-  const onSetShowPolygonAddresses = useCallback(
+  const onSetObjectAddressesVisible = useCallback(
     (_: SyntheticEvent<Element, Event>, value: boolean) => {
-      viewOptions.setShowPolygonAddresses(value);
+      viewOptions.setObjectAddressesVisible(value);
     },
-    [viewOptions.setShowPolygonAddresses]
+    [viewOptions.setObjectAddressesVisible]
   );
 
-  const onSetShowSceneCursor = useCallback(
+  const onSetSceneCursorVisible = useCallback(
     (_: SyntheticEvent<Element, Event>, value: boolean) => {
-      viewOptions.setShowSceneCursor(value);
+      viewOptions.setSceneCursorVisible(value);
     },
-    [viewOptions.setShowSceneCursor]
+    [viewOptions.setSceneCursorVisible]
   );
 
   const textures = useMemo(() => {
@@ -388,23 +388,23 @@ export default function GuiPanel() {
         </Grid>
         {viewOptions.meshDisplayMode !== 'wireframe' ? undefined : (
           <FormControlLabel
-            control={<Checkbox checked={viewOptions.showPolygonAddresses} />}
+            control={<Checkbox checked={viewOptions.objectAddressesVisible} />}
             label='Addresses'
             labelPlacement='start'
-            onChange={onSetShowPolygonAddresses}
+            onChange={onSetObjectAddressesVisible}
           />
         )}
         <FormControlLabel
-          control={<Checkbox checked={viewOptions.showAxesHelper} />}
+          control={<Checkbox checked={viewOptions.axesHelperVisible} />}
           label='Axes Helper'
           labelPlacement='start'
-          onChange={onSetShowAxesHelper}
+          onChange={onSetAxesHelperVisible}
         />
         <FormControlLabel
-          control={<Checkbox checked={viewOptions.showSceneCursor} />}
+          control={<Checkbox checked={viewOptions.sceneCursorVisible} />}
           label='Scene Cursor'
           labelPlacement='start'
-          onChange={onSetShowSceneCursor}
+          onChange={onSetSceneCursorVisible}
         />
       </div>
       {!hasLoadedStageTextureFile ? undefined : (

--- a/src/components/scene/RenderedMesh.tsx
+++ b/src/components/scene/RenderedMesh.tsx
@@ -1,7 +1,9 @@
+import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import RenderedPolygon from './RenderedPolygon';
 import { NLTextureDef } from '@/types/NLAbstractions';
 import { useTexture } from '@react-three/drei';
 import { ClampToEdgeWrapping, RepeatWrapping } from 'three';
+import { useContext } from 'react';
 
 type RenderedMeshProps = {
   objectKey: string;

--- a/src/components/scene/RenderedPolygon.tsx
+++ b/src/components/scene/RenderedPolygon.tsx
@@ -21,7 +21,12 @@ export default function RenderedPolygon({
   onSelectObjectKey: (key: string) => void;
   texture?: Texture;
 }) {
-  const { meshDisplayMode, objectAddressesVisible } =
+  // @TODO: consider breaking down mesh material and components
+  // to absorb context in subtrees if performance becomes an issue with
+  // settings change scenario for user interactions
+  // (seems not to be the case with workflows so far)
+
+  const { meshDisplayMode, objectAddressesVisible, wireframeLineWidth } =
     useContext(ViewOptionsContext);
   const textRef = useRef();
   const theme = useTheme();
@@ -94,7 +99,9 @@ export default function RenderedPolygon({
     meshDisplayMode === 'wireframe'
       ? {
           wireframe: true,
-          wireframeLinewidth: isSelected ? 4 : 3
+          wireframeLinewidth: isSelected
+            ? Math.round(wireframeLineWidth * 1.25)
+            : wireframeLineWidth
         }
       : {
           map: texture,

--- a/src/components/scene/RenderedPolygon.tsx
+++ b/src/components/scene/RenderedPolygon.tsx
@@ -21,7 +21,7 @@ export default function RenderedPolygon({
   onSelectObjectKey: (key: string) => void;
   texture?: Texture;
 }) {
-  const { meshDisplayMode, showPolygonAddresses } =
+  const { meshDisplayMode, objectAddressesVisible } =
     useContext(ViewOptionsContext);
   const textRef = useRef();
   const theme = useTheme();
@@ -112,7 +112,7 @@ export default function RenderedPolygon({
 
     return !isSelected ||
       meshDisplayMode === 'textured' ||
-      !showPolygonAddresses ? undefined : (
+      !objectAddressesVisible ? undefined : (
       <Text
         font={'/fonts/robotoLightRegular.json'}
         fontSize={16}
@@ -123,7 +123,7 @@ export default function RenderedPolygon({
         [{objectKey}] {`0x${address.toString(16)}`}
       </Text>
     );
-  }, [color, showPolygonAddresses, meshDisplayMode, isSelected]);
+  }, [color, objectAddressesVisible, meshDisplayMode, isSelected]);
 
   const handleClick = (e: ThreeEvent<MouseEvent>) => {
     e.nativeEvent.stopPropagation();

--- a/src/components/scene/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas.tsx
@@ -52,9 +52,9 @@ export default function SceneCanvas() {
   const canvasStyle = useMemo(
     () => ({
       background: theme.palette.scene.background,
-      cursor: viewOptions.showSceneCursor ? 'default' : 'none'
+      cursor: viewOptions.sceneCursorVisible ? 'default' : 'none'
     }),
-    [viewOptions.showSceneCursor, theme]
+    [viewOptions.sceneCursorVisible, theme]
   );
 
   return (
@@ -62,7 +62,7 @@ export default function SceneCanvas() {
       <Canvas camera={cameraParams} frameloop='demand' style={canvasStyle}>
         <SceneContextSetup />
         <group dispose={null}>
-          {!viewOptions.showAxesHelper ? undefined : <axesHelper args={[50]} />}
+          {!viewOptions.axesHelperVisible ? undefined : <axesHelper args={[50]} />}
           {(model?.meshes || []).map((m, i) => (
             <RenderedMesh
               key={m.address}

--- a/src/components/scene/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas.tsx
@@ -62,7 +62,9 @@ export default function SceneCanvas() {
       <Canvas camera={cameraParams} frameloop='demand' style={canvasStyle}>
         <SceneContextSetup />
         <group dispose={null}>
-          {!viewOptions.axesHelperVisible ? undefined : <axesHelper args={[50]} />}
+          {!viewOptions.axesHelperVisible ? undefined : (
+            <axesHelper args={[50]} />
+          )}
           {(model?.meshes || []).map((m, i) => (
             <RenderedMesh
               key={m.address}

--- a/src/constants/PersistentSettingsKeys.ts
+++ b/src/constants/PersistentSettingsKeys.ts
@@ -1,8 +1,0 @@
-/**
- * mapping of user-defined settings that
- * persist keys to values
- */
-export const PersistentSettingsKeys = {
-  MeshDisplayMode: 'meshDisplayMode',
-  AxesHelperVisible: 'axesHelperVisible'
-} as const;

--- a/src/constants/PersistentSettingsKeys.ts
+++ b/src/constants/PersistentSettingsKeys.ts
@@ -1,0 +1,8 @@
+/**
+ * mapping of user-defined settings that
+ * persist keys to values
+ */
+export const PersistentSettingsKeys = {
+  MeshDisplayMode: 'meshDisplayMode',
+  AxesHelperVisible: 'axesHelperVisible'
+} as const;

--- a/src/constants/StorageKeys.ts
+++ b/src/constants/StorageKeys.ts
@@ -1,0 +1,11 @@
+/**
+ * mapping of user-defined settings that
+ * persist keys to values
+ */
+export const StorageKeys = {
+  MESH_DISPLAY_MODE: 'meshDisplayMode',
+  AXES_HELPER_VISIBLE: 'axesHelperVisible',
+  OBJECT_ADDRESSES_VISIBLE: 'objectAddressesVisible',
+  SCENE_CURSOR_VISIBLE: 'sceneCursorVisible',
+  GUI_PANEL_VISIBLE: 'guiPanelVisible'
+} as const;

--- a/src/constants/StorageKeys.ts
+++ b/src/constants/StorageKeys.ts
@@ -4,6 +4,7 @@
  */
 export const StorageKeys = {
   MESH_DISPLAY_MODE: 'meshDisplayMode',
+  WIREFRAME_LINE_THICKNESS: 'wireframeLineThickness',
   AXES_HELPER_VISIBLE: 'axesHelperVisible',
   OBJECT_ADDRESSES_VISIBLE: 'objectAddressesVisible',
   SCENE_CURSOR_VISIBLE: 'sceneCursorVisible',

--- a/src/constants/StorageKeys.ts
+++ b/src/constants/StorageKeys.ts
@@ -4,7 +4,7 @@
  */
 export const StorageKeys = {
   MESH_DISPLAY_MODE: 'meshDisplayMode',
-  WIREFRAME_LINE_THICKNESS: 'wireframeLineThickness',
+  WIREFRAME_LINE_WIDTH: 'wireframeLineWidth',
   AXES_HELPER_VISIBLE: 'axesHelperVisible',
   OBJECT_ADDRESSES_VISIBLE: 'objectAddressesVisible',
   SCENE_CURSOR_VISIBLE: 'sceneCursorVisible',

--- a/src/contexts/ViewOptionsContext.tsx
+++ b/src/contexts/ViewOptionsContext.tsx
@@ -10,40 +10,41 @@ import React, {
 export type MeshDisplayMode = 'wireframe' | 'textured';
 
 export type ViewOptions = {
-  showAxesHelper: boolean;
-  showSceneCursor: boolean;
-  showGuiPanel: boolean;
-  showPolygonAddresses: boolean;
+  axesHelperVisible: boolean;
+  sceneCursorVisible: boolean;
+  guiPanelVisible: boolean;
+  objectAddressesVisible: boolean;
   meshDisplayMode: MeshDisplayMode;
-  setShowAxesHelper: (showAxesHelper: boolean) => void;
-  setShowSceneCursor: (showSceneCursor: boolean) => void;
-  setShowGuiPanel: (showGuiPanel: boolean) => void;
-  setShowPolygonAddresses: (showPolygonAddresses: boolean) => void;
+  setAxesHelperVisible: (axesHelperVisible: boolean) => void;
+  setSceneCursorVisible: (sceneCursorVisible: boolean) => void;
+  setGuiPanelVisible: (guiPanelVisible: boolean) => void;
+  setObjectAddressesVisible: (objectAddressesVisible: boolean) => void;
   setMeshDisplayMode: (meshDisplayMode: MeshDisplayMode) => void;
 };
 
 export const ViewOptionsContext = React.createContext<ViewOptions>({
-  showAxesHelper: true,
-  showSceneCursor: true,
-  showGuiPanel: true,
-  showPolygonAddresses: true,
+  axesHelperVisible: true,
+  sceneCursorVisible: true,
+  guiPanelVisible: true,
+  objectAddressesVisible: true,
   meshDisplayMode: 'wireframe',
-  setShowAxesHelper: (_: boolean) => null,
-  setShowSceneCursor: (_: boolean) => null,
-  setShowGuiPanel: (_: boolean) => null,
-  setShowPolygonAddresses: (_: boolean) => null,
+  setAxesHelperVisible: (_: boolean) => null,
+  setSceneCursorVisible: (_: boolean) => null,
+  setGuiPanelVisible: (_: boolean) => null,
+  setObjectAddressesVisible: (_: boolean) => null,
   setMeshDisplayMode: (_: MeshDisplayMode) => null
 });
 
 type Props = { children: ReactNode };
 
 export function ViewOptionsContextProvider({ children }: Props) {
-  const [showAxesHelper, handleSetShowAxesHelper] = useState(true);
-  const [showPolygonAddresses, handleSetShowPolygonAddresses] = useState(true);
-  const [showGuiPanel, handleSetShowGuiPanel] = useState(true);
+  const [axesHelperVisible, handleSetAxesHelperVisible] = useState(true);
+  const [objectAddressesVisible, handleSetObjectAddressesVisible] =
+    useState(true);
+  const [guiPanelVisible, handleSetGuiPanelVisible] = useState(true);
   const [meshDisplayMode, handleSetMeshDisplayMode] =
     useState<MeshDisplayMode>('wireframe');
-  const [showSceneCursor, handleSetShowSceneCursor] = useState(true);
+  const [sceneCursorVisible, handleSetSceneCursorVisible] = useState(true);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -58,57 +59,59 @@ export function ViewOptionsContextProvider({ children }: Props) {
       );
     }
 
-    if (localStorage.getItem('showAxesHelper') !== null) {
-      handleSetShowAxesHelper(
-        JSON.parse(localStorage.getItem('showAxesHelper') || 'true') as boolean
+    if (localStorage.getItem('axesHelperVisible') !== null) {
+      handleSetAxesHelperVisible(
+        JSON.parse(
+          localStorage.getItem('axesHelperVisible') || 'true'
+        ) as boolean
       );
     }
 
-    if (localStorage.getItem('showPolygonAddresses') !== null) {
-      handleSetShowPolygonAddresses(
+    if (localStorage.getItem('objectAddressesVisible') !== null) {
+      handleSetObjectAddressesVisible(
         JSON.parse(
-          localStorage.getItem('showPolygonAddresses') || 'true'
+          localStorage.getItem('objectAddressesVisible') || 'true'
         ) as boolean
       );
     }
   }, []);
 
-  const setShowPolygonAddresses = useCallback(
+  const setObjectAddressesVisible = useCallback(
     (value: boolean) => {
-      if (showPolygonAddresses !== value) {
-        localStorage.setItem('showPolygonAddresses', `${value}`);
-        handleSetShowPolygonAddresses(value);
+      if (objectAddressesVisible !== value) {
+        localStorage.setItem('objectAddressesVisible', `${value}`);
+        handleSetObjectAddressesVisible(value);
       }
     },
-    [showPolygonAddresses]
+    [objectAddressesVisible]
   );
 
-  const setShowSceneCursor = useCallback(
+  const setSceneCursorVisible = useCallback(
     (value: boolean) => {
-      if (showSceneCursor !== value) {
-        handleSetShowSceneCursor(value);
+      if (sceneCursorVisible !== value) {
+        handleSetSceneCursorVisible(value);
       }
     },
-    [showSceneCursor]
+    [sceneCursorVisible]
   );
 
-  const setShowGuiPanel = useCallback(
+  const setGuiPanelVisible = useCallback(
     (value: boolean) => {
-      if (showGuiPanel !== value) {
-        handleSetShowGuiPanel(value);
+      if (guiPanelVisible !== value) {
+        handleSetGuiPanelVisible(value);
       }
     },
-    [showGuiPanel]
+    [guiPanelVisible]
   );
 
-  const setShowAxesHelper = useCallback(
+  const setAxesHelperVisible = useCallback(
     (value: boolean) => {
-      if (showAxesHelper !== value) {
-        localStorage.setItem('showAxesHelper', `${value}`);
-        handleSetShowAxesHelper(value);
+      if (axesHelperVisible !== value) {
+        localStorage.setItem('axesHelperVisible', `${value}`);
+        handleSetAxesHelperVisible(value);
       }
     },
-    [showAxesHelper]
+    [axesHelperVisible]
   );
 
   const setMeshDisplayMode = useCallback(
@@ -123,28 +126,28 @@ export function ViewOptionsContextProvider({ children }: Props) {
 
   const contextValue = useMemo<ViewOptions>(
     () => ({
-      showPolygonAddresses,
-      setShowPolygonAddresses,
-      showSceneCursor,
-      setShowSceneCursor,
-      showAxesHelper,
-      setShowAxesHelper,
+      objectAddressesVisible,
+      setObjectAddressesVisible,
+      sceneCursorVisible,
+      setSceneCursorVisible,
+      axesHelperVisible,
+      setAxesHelperVisible,
       meshDisplayMode,
       setMeshDisplayMode,
-      showGuiPanel,
-      setShowGuiPanel
+      guiPanelVisible,
+      setGuiPanelVisible
     }),
     [
-      showPolygonAddresses,
-      setShowPolygonAddresses,
-      showSceneCursor,
-      setShowSceneCursor,
-      showAxesHelper,
-      setShowAxesHelper,
+      objectAddressesVisible,
+      setObjectAddressesVisible,
+      sceneCursorVisible,
+      setSceneCursorVisible,
+      axesHelperVisible,
+      setAxesHelperVisible,
       meshDisplayMode,
       setMeshDisplayMode,
-      showGuiPanel,
-      setShowGuiPanel
+      guiPanelVisible,
+      setGuiPanelVisible
     ]
   );
 

--- a/src/contexts/ViewOptionsContext.tsx
+++ b/src/contexts/ViewOptionsContext.tsx
@@ -16,13 +16,13 @@ export type ViewOptions = {
   guiPanelVisible: boolean;
   objectAddressesVisible: boolean;
   meshDisplayMode: MeshDisplayMode;
-  wireframeLineThickness: number;
+  wireframeLineWidth: number;
   setAxesHelperVisible: (axesHelperVisible: boolean) => void;
   setSceneCursorVisible: (sceneCursorVisible: boolean) => void;
   setGuiPanelVisible: (guiPanelVisible: boolean) => void;
   setObjectAddressesVisible: (objectAddressesVisible: boolean) => void;
   setMeshDisplayMode: (meshDisplayMode: MeshDisplayMode) => void;
-  setWireframeLineThickness: (wireframeLineThickness: number) => void;
+  setWireframeLineWidth: (wireframeLineWidth: number) => void;
 };
 
 export const ViewOptionsContext = React.createContext<ViewOptions>({
@@ -31,13 +31,13 @@ export const ViewOptionsContext = React.createContext<ViewOptions>({
   guiPanelVisible: true,
   objectAddressesVisible: true,
   meshDisplayMode: 'wireframe',
-  wireframeLineThickness: 3,
+  wireframeLineWidth: 3,
   setAxesHelperVisible: (_: boolean) => null,
   setSceneCursorVisible: (_: boolean) => null,
   setGuiPanelVisible: (_: boolean) => null,
   setObjectAddressesVisible: (_: boolean) => null,
   setMeshDisplayMode: (_: MeshDisplayMode) => null,
-  setWireframeLineThickness: (_: number) => null
+  setWireframeLineWidth: (_: number) => null
 });
 
 type Props = { children: ReactNode };
@@ -50,7 +50,7 @@ export function ViewOptionsContextProvider({ children }: Props) {
   const [meshDisplayMode, handleSetMeshDisplayMode] =
     useState<MeshDisplayMode>('wireframe');
   const [sceneCursorVisible, handleSetSceneCursorVisible] = useState(true);
-  const [wireframeLineThickness, handleSetWireframeLineThickness] = useState(3);
+  const [wireframeLineWidth, handleSetWireframeLineWidth] = useState(3);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -81,10 +81,10 @@ export function ViewOptionsContextProvider({ children }: Props) {
       );
     }
 
-    if (localStorage.getItem(StorageKeys.WIREFRAME_LINE_THICKNESS) !== null) {
-      handleSetWireframeLineThickness(
+    if (localStorage.getItem(StorageKeys.WIREFRAME_LINE_WIDTH) !== null) {
+      handleSetWireframeLineWidth(
         Number(
-          localStorage.getItem(StorageKeys.WIREFRAME_LINE_THICKNESS) || 3
+          localStorage.getItem(StorageKeys.WIREFRAME_LINE_WIDTH) || 3
         ) as number
       );
     }
@@ -138,14 +138,14 @@ export function ViewOptionsContextProvider({ children }: Props) {
     [meshDisplayMode]
   );
 
-  const setWireframeLineThickness = useCallback(
+  const setWireframeLineWidth = useCallback(
     (value: number) => {
-      if (wireframeLineThickness !== value) {
-        localStorage.setItem(StorageKeys.WIREFRAME_LINE_THICKNESS, `${value}`);
-        handleSetWireframeLineThickness(value);
+      if (wireframeLineWidth !== value) {
+        localStorage.setItem(StorageKeys.WIREFRAME_LINE_WIDTH, `${value}`);
+        handleSetWireframeLineWidth(value);
       }
     },
-    [wireframeLineThickness]
+    [wireframeLineWidth]
   );
 
   const contextValue = useMemo<ViewOptions>(
@@ -160,8 +160,8 @@ export function ViewOptionsContextProvider({ children }: Props) {
       setMeshDisplayMode,
       guiPanelVisible,
       setGuiPanelVisible,
-      wireframeLineThickness,
-      setWireframeLineThickness
+      wireframeLineWidth,
+      setWireframeLineWidth
     }),
     [
       objectAddressesVisible,
@@ -172,8 +172,8 @@ export function ViewOptionsContextProvider({ children }: Props) {
       setAxesHelperVisible,
       meshDisplayMode,
       setMeshDisplayMode,
-      wireframeLineThickness,
-      setWireframeLineThickness,
+      wireframeLineWidth,
+      setWireframeLineWidth,
       guiPanelVisible,
       setGuiPanelVisible
     ]

--- a/src/contexts/ViewOptionsContext.tsx
+++ b/src/contexts/ViewOptionsContext.tsx
@@ -16,11 +16,13 @@ export type ViewOptions = {
   guiPanelVisible: boolean;
   objectAddressesVisible: boolean;
   meshDisplayMode: MeshDisplayMode;
+  wireframeLineThickness: number;
   setAxesHelperVisible: (axesHelperVisible: boolean) => void;
   setSceneCursorVisible: (sceneCursorVisible: boolean) => void;
   setGuiPanelVisible: (guiPanelVisible: boolean) => void;
   setObjectAddressesVisible: (objectAddressesVisible: boolean) => void;
   setMeshDisplayMode: (meshDisplayMode: MeshDisplayMode) => void;
+  setWireframeLineThickness: (wireframeLineThickness: number) => void;
 };
 
 export const ViewOptionsContext = React.createContext<ViewOptions>({
@@ -29,11 +31,13 @@ export const ViewOptionsContext = React.createContext<ViewOptions>({
   guiPanelVisible: true,
   objectAddressesVisible: true,
   meshDisplayMode: 'wireframe',
+  wireframeLineThickness: 3,
   setAxesHelperVisible: (_: boolean) => null,
   setSceneCursorVisible: (_: boolean) => null,
   setGuiPanelVisible: (_: boolean) => null,
   setObjectAddressesVisible: (_: boolean) => null,
-  setMeshDisplayMode: (_: MeshDisplayMode) => null
+  setMeshDisplayMode: (_: MeshDisplayMode) => null,
+  setWireframeLineThickness: (_: number) => null
 });
 
 type Props = { children: ReactNode };
@@ -46,6 +50,7 @@ export function ViewOptionsContextProvider({ children }: Props) {
   const [meshDisplayMode, handleSetMeshDisplayMode] =
     useState<MeshDisplayMode>('wireframe');
   const [sceneCursorVisible, handleSetSceneCursorVisible] = useState(true);
+  const [wireframeLineThickness, handleSetWireframeLineThickness] = useState(3);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -73,6 +78,14 @@ export function ViewOptionsContextProvider({ children }: Props) {
         JSON.parse(
           localStorage.getItem(StorageKeys.OBJECT_ADDRESSES_VISIBLE) || 'true'
         ) as boolean
+      );
+    }
+
+    if (localStorage.getItem(StorageKeys.WIREFRAME_LINE_THICKNESS) !== null) {
+      handleSetWireframeLineThickness(
+        Number(
+          localStorage.getItem(StorageKeys.WIREFRAME_LINE_THICKNESS) || 3
+        ) as number
       );
     }
   }, []);
@@ -125,6 +138,16 @@ export function ViewOptionsContextProvider({ children }: Props) {
     [meshDisplayMode]
   );
 
+  const setWireframeLineThickness = useCallback(
+    (value: number) => {
+      if (wireframeLineThickness !== value) {
+        localStorage.setItem(StorageKeys.WIREFRAME_LINE_THICKNESS, `${value}`);
+        handleSetWireframeLineThickness(value);
+      }
+    },
+    [wireframeLineThickness]
+  );
+
   const contextValue = useMemo<ViewOptions>(
     () => ({
       objectAddressesVisible,
@@ -136,7 +159,9 @@ export function ViewOptionsContextProvider({ children }: Props) {
       meshDisplayMode,
       setMeshDisplayMode,
       guiPanelVisible,
-      setGuiPanelVisible
+      setGuiPanelVisible,
+      wireframeLineThickness,
+      setWireframeLineThickness
     }),
     [
       objectAddressesVisible,
@@ -147,6 +172,8 @@ export function ViewOptionsContextProvider({ children }: Props) {
       setAxesHelperVisible,
       meshDisplayMode,
       setMeshDisplayMode,
+      wireframeLineThickness,
+      setWireframeLineThickness,
       guiPanelVisible,
       setGuiPanelVisible
     ]

--- a/src/contexts/ViewOptionsContext.tsx
+++ b/src/contexts/ViewOptionsContext.tsx
@@ -6,6 +6,7 @@ import React, {
   useCallback,
   useEffect
 } from 'react';
+import { StorageKeys } from '@/constants/StorageKeys';
 
 export type MeshDisplayMode = 'wireframe' | 'textured';
 
@@ -52,25 +53,25 @@ export function ViewOptionsContextProvider({ children }: Props) {
     }
 
     const { localStorage } = window;
-    if (localStorage.getItem('meshDisplayMode') !== null) {
+    if (localStorage.getItem(StorageKeys.MESH_DISPLAY_MODE) !== null) {
       handleSetMeshDisplayMode(
-        (localStorage.getItem('meshDisplayMode') ||
+        (localStorage.getItem(StorageKeys.MESH_DISPLAY_MODE) ||
           'wireframe') as MeshDisplayMode
       );
     }
 
-    if (localStorage.getItem('axesHelperVisible') !== null) {
+    if (localStorage.getItem(StorageKeys.AXES_HELPER_VISIBLE) !== null) {
       handleSetAxesHelperVisible(
         JSON.parse(
-          localStorage.getItem('axesHelperVisible') || 'true'
+          localStorage.getItem(StorageKeys.AXES_HELPER_VISIBLE) || 'true'
         ) as boolean
       );
     }
 
-    if (localStorage.getItem('objectAddressesVisible') !== null) {
+    if (localStorage.getItem(StorageKeys.OBJECT_ADDRESSES_VISIBLE) !== null) {
       handleSetObjectAddressesVisible(
         JSON.parse(
-          localStorage.getItem('objectAddressesVisible') || 'true'
+          localStorage.getItem(StorageKeys.OBJECT_ADDRESSES_VISIBLE) || 'true'
         ) as boolean
       );
     }
@@ -79,7 +80,7 @@ export function ViewOptionsContextProvider({ children }: Props) {
   const setObjectAddressesVisible = useCallback(
     (value: boolean) => {
       if (objectAddressesVisible !== value) {
-        localStorage.setItem('objectAddressesVisible', `${value}`);
+        localStorage.setItem(StorageKeys.OBJECT_ADDRESSES_VISIBLE, `${value}`);
         handleSetObjectAddressesVisible(value);
       }
     },
@@ -107,7 +108,7 @@ export function ViewOptionsContextProvider({ children }: Props) {
   const setAxesHelperVisible = useCallback(
     (value: boolean) => {
       if (axesHelperVisible !== value) {
-        localStorage.setItem('axesHelperVisible', `${value}`);
+        localStorage.setItem(StorageKeys.AXES_HELPER_VISIBLE, `${value}`);
         handleSetAxesHelperVisible(value);
       }
     },
@@ -117,7 +118,7 @@ export function ViewOptionsContextProvider({ children }: Props) {
   const setMeshDisplayMode = useCallback(
     (value: MeshDisplayMode) => {
       if (meshDisplayMode !== value) {
-        localStorage.setItem('meshDisplayMode', `${value}`);
+        localStorage.setItem(StorageKeys.MESH_DISPLAY_MODE, `${value}`);
         handleSetMeshDisplayMode(value);
       }
     },

--- a/src/hooks/useSceneKeyboardActions.ts
+++ b/src/hooks/useSceneKeyboardActions.ts
@@ -30,7 +30,7 @@ export default function useSceneKeyboardActions() {
 
   useEffect(() => {
     if (isSlashPressed && isControlPressed) {
-      viewOptions.setShowGuiPanel(!viewOptions.showGuiPanel);
+      viewOptions.setGuiPanelVisible(!viewOptions.guiPanelVisible);
     }
   }, [isSlashPressed, isControlPressed]);
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,7 +35,7 @@ export default function Home() {
       </Head>
       <Styled>
         <SceneCanvas />
-        {!viewOptions.showGuiPanel ? undefined : <GuiPanel />}
+        {!viewOptions.guiPanelVisible ? undefined : <GuiPanel />}
       </Styled>
       <CssBaseline />
     </>


### PR DESCRIPTION
Minor refactor of view options while also adding an additional option to edit wireframe line width.

note: line thickness option is available internally for now, but work done towards that to be added sooner than planned because of a specific user request. 

There is a need to switch rendering slightly to line geometry to utilize it effectively but that will come after sorting vertex indices and normals to display properly (already in progress).