### PR TITLE
iterate file loading logic towards compressed-texture support

### DIFF
--- a/src/store/nonSerializables.ts
+++ b/src/store/nonSerializables.ts
@@ -4,11 +4,11 @@
 // data (at least immediate e.g. JSON)
 
 const nonSerializables: {
-  stagePolygonFile?: File;
-  textureFile?: File;
+  polygonBuffer?: Buffer;
+  textureBuffer?: Buffer;
 } = {
-  stagePolygonFile: undefined,
-  textureFile: undefined
+  polygonBuffer: undefined,
+  textureBuffer: undefined
 };
 
 export default nonSerializables;

--- a/src/store/stage-data/exportTextureFile.ts
+++ b/src/store/stage-data/exportTextureFile.ts
@@ -48,12 +48,10 @@ export default async function exportTextureFile(
   textureDefs: NLTextureDef[],
   textureFileName = ''
 ): Promise<void> {
-  const { textureFile } = nonSerializables;
-  if (!textureFile) {
+  const { textureBuffer } = nonSerializables;
+  if (!textureBuffer) {
     return;
   }
-
-  const buffer = Buffer.from(await textureFile.arrayBuffer());
 
   for await (const t of textureDefs) {
     const { baseLocation, ramOffset, width, height } = t;
@@ -76,12 +74,14 @@ export default async function exportTextureFile(
         const conversionOp = conversionDict[t.colorFormat];
         const offsetWritten = baseLocation - ramOffset + offset * COLOR_SIZE;
 
-        buffer.writeUInt16LE(conversionOp(color), offsetWritten);
+        textureBuffer.writeUInt16LE(conversionOp(color), offsetWritten);
       }
     }
   }
 
-  const output = new Blob([buffer], { type: 'application/octet-stream' });
+  const output = new Blob([textureBuffer], {
+    type: 'application/octet-stream'
+  });
   const link = document.createElement('a');
   link.href = window.URL.createObjectURL(output);
 

--- a/src/store/stage-data/processPolygonBuffer.ts
+++ b/src/store/stage-data/processPolygonBuffer.ts
@@ -2,17 +2,13 @@ import scanModel from './process-stage-polygon-file/scanModel';
 import scanForModelPointers from './process-stage-polygon-file/scanForModelPointers';
 import scanTextureHeaderData from './process-stage-polygon-file/scanTextureHeaderData';
 import { NLTextureDef } from '@/types/NLAbstractions';
-import nonSerializables from '../nonSerializables';
 
-export default async function processPolygonFile(
-  stagePolygonFile: File
-): Promise<{
+export default async function processPolygonBuffer(buffer: Buffer): Promise<{
   modelRamOffset: number;
   models: NLModel[];
   textureDefs: NLTextureDef[];
-  fileName: string;
+  buffer: Buffer;
 }> {
-  const buffer = Buffer.from(await stagePolygonFile.arrayBuffer());
   const [modelPointers, modelRamOffset] = scanForModelPointers(buffer);
 
   // @TODO: run these on separate thread
@@ -24,11 +20,10 @@ export default async function processPolygonFile(
       scanModel({ buffer, address, index }) as NLModel
   );
 
-  nonSerializables.stagePolygonFile = stagePolygonFile;
   return Promise.resolve({
     modelRamOffset,
     models,
     textureDefs,
-    fileName: stagePolygonFile.name
+    buffer
   });
 }

--- a/src/store/stage-data/processTextureBuffer.ts
+++ b/src/store/stage-data/processTextureBuffer.ts
@@ -6,7 +6,7 @@ import {
 } from '@/utils/textures/parse';
 import { NLTextureDef, TextureDataUrlType } from '@/types/NLAbstractions';
 import { RgbaColor, TextureColorFormat } from '@/utils/textures';
-import nonSerializables from '../nonSerializables';
+
 const COLOR_SIZE = 2;
 
 const unsupportedConversion = () => ({ r: 0, g: 0, b: 0, a: 0 });
@@ -19,18 +19,15 @@ const conversionDict: Record<TextureColorFormat, (color: number) => RgbaColor> =
     ARGB8888: unsupportedConversion
   };
 
-export default async function processTextureFile(
-  textureFile: File,
+export default async function processTextureBuffer(
+  buffer: Buffer,
   models: NLModel[],
   textureDefs: NLTextureDef[]
 ): Promise<{
   models: NLModel[];
   textureDefs: NLTextureDef[];
-  fileName: string;
 }> {
   const nextTextureDefs: NLTextureDef[] = [];
-
-  const buffer = Buffer.from(await textureFile.arrayBuffer());
 
   for await (const t of textureDefs) {
     const dataUrlTypes = Object.keys(t.dataUrls) as TextureDataUrlType[];
@@ -88,11 +85,8 @@ export default async function processTextureFile(
     nextTextureDefs.push(updatedTexture);
   }
 
-  nonSerializables.textureFile = textureFile;
-
   return Promise.resolve({
     models,
-    textureDefs: nextTextureDefs,
-    fileName: textureFile.name
+    textureDefs: nextTextureDefs
   });
 }

--- a/src/utils/textures/parse/decompressTextureBuffer.ts
+++ b/src/utils/textures/parse/decompressTextureBuffer.ts
@@ -1,0 +1,4 @@
+export default function decompressTextureBuffer(buffer: Buffer) {
+  // TODO: logic here to decompress texture buffer
+  return buffer;
+}

--- a/src/utils/textures/parse/index.ts
+++ b/src/utils/textures/parse/index.ts
@@ -1,3 +1,4 @@
+export { default as decompressTextureBuffer } from './decompressTextureBuffer';
 export { default as argb1555ToRgba8888 } from './argb1555ToRgba8888';
 export { default as argb4444ToRgba8888 } from './argb4444ToRgba8888';
 export { default as encodeZMortonPosition } from './encodeZMortonPosition';


### PR DESCRIPTION
- now stores buffers vs entire file container since these will be operated on once decompressed
- assume errors in texture parsing imply we are working on compressed texture data since compressed textures will always throw a range error when scanning addresses referenced from polygon file texture headers -- *note that this is all just MVP functionality so users can load textures in general and will be expanded/iterated on later*