### PR TITLE
progress on compressed texture support

### DIFF
--- a/src/components/panel/GuiPanel.tsx
+++ b/src/components/panel/GuiPanel.tsx
@@ -11,7 +11,8 @@ import {
   selectSceneTextureDefs,
   setObjectType,
   useAppDispatch,
-  useAppSelector
+  useAppSelector,
+  selectHasCompressedTextures
 } from '@/store';
 import {
   Button,
@@ -278,7 +279,7 @@ export default function GuiPanel() {
     return images;
   }, [model, textureDefs, selectedMeshTexture]);
 
-  const hasEditedTextures = useAppSelector(selectHasEditedTextures);
+  const hasCompressedTextures = useAppSelector(selectHasCompressedTextures);
 
   // when selecting a texture, scroll to the item
   useEffect(() => {
@@ -481,19 +482,21 @@ export default function GuiPanel() {
             <div className='textures'>{textures}</div>
           </>
         )}
-        <div>
-          <Tooltip title='Download texture ROM binary with replaced images'>
-            <Button
-              onClick={onExportTextureFile}
-              fullWidth
-              color='secondary'
-              size='small'
-              variant='outlined'
-            >
-              Export Textures
-            </Button>
-          </Tooltip>
-        </div>
+        {!hasLoadedTextureFile || hasCompressedTextures ? undefined : (
+          <div>
+            <Tooltip title='Download texture ROM binary with replaced images'>
+              <Button
+                onClick={onExportTextureFile}
+                fullWidth
+                color='secondary'
+                size='small'
+                variant='outlined'
+              >
+                Export Textures
+              </Button>
+            </Tooltip>
+          </div>
+        )}
       </div>
     </StyledPaper>
   );

--- a/src/components/panel/GuiPanel.tsx
+++ b/src/components/panel/GuiPanel.tsx
@@ -481,21 +481,19 @@ export default function GuiPanel() {
             <div className='textures'>{textures}</div>
           </>
         )}
-        {!hasEditedTextures ? undefined : (
-          <div>
-            <Tooltip title='Download texture ROM binary with replaced images'>
-              <Button
-                onClick={onExportTextureFile}
-                fullWidth
-                color='secondary'
-                size='small'
-                variant='outlined'
-              >
-                Export Textures
-              </Button>
-            </Tooltip>
-          </div>
-        )}
+        <div>
+          <Tooltip title='Download texture ROM binary with replaced images'>
+            <Button
+              onClick={onExportTextureFile}
+              fullWidth
+              color='secondary'
+              size='small'
+              variant='outlined'
+            >
+              Export Textures
+            </Button>
+          </Tooltip>
+        </div>
       </div>
     </StyledPaper>
   );

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -125,6 +125,7 @@ export const loadTextureFile = createAsyncThunk<
       fileName,
       hasCompressedTextures: false
     };
+    nonSerializables.textureBuffer = buffer;
   } catch (error) {
     // if an overflow error occurs, this is an indicator that the
     // file loaded is compressed; this is common for certain
@@ -140,9 +141,9 @@ export const loadTextureFile = createAsyncThunk<
       fileName,
       hasCompressedTextures: true
     };
+    nonSerializables.textureBuffer = decompressedBuffer;
   }
 
-  nonSerializables.textureBuffer = buffer;
   return result;
 });
 
@@ -182,7 +183,15 @@ export const downloadTextureFile = createAsyncThunk<
   const state = getState();
   const { textureFileName, hasCompressedTextures } = state.modelData;
   const textureDefs = selectSceneTextureDefs(state);
-  await exportTextureFile(textureDefs, textureFileName, hasCompressedTextures);
+  try {
+    await exportTextureFile(
+      textureDefs,
+      textureFileName,
+      hasCompressedTextures
+    );
+  } catch (error) {
+    console.error(error);
+  }
 });
 
 const modelDataSlice = createSlice({

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -271,7 +271,9 @@ const modelDataSlice = createSlice({
 
           state.editedTextures = Object.fromEntries(entries);
         }
-        state.hasEditedTextures = Object.keys(state.editedTextures).length > 0;
+        state.hasEditedTextures =
+          state.hasEditedTextures ||
+          Object.keys(state.editedTextures).length > 0;
       }
     );
 

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -180,9 +180,9 @@ export const downloadTextureFile = createAsyncThunk<
   { state: AppState }
 >(`${sliceName}/downloadTextureFile`, async (_, { getState }) => {
   const state = getState();
-  const { textureFileName } = state.modelData;
+  const { textureFileName, hasCompressedTextures } = state.modelData;
   const textureDefs = selectSceneTextureDefs(state);
-  await exportTextureFile(textureDefs, textureFileName);
+  await exportTextureFile(textureDefs, textureFileName, hasCompressedTextures);
 });
 
 const modelDataSlice = createSlice({

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -13,6 +13,9 @@ export const selectHasLoadedTextureFile = (s: AppState) =>
 export const selectHasEditedTextures = (s: AppState) =>
   s.modelData.hasEditedTextures;
 
+export const selectHasCompressedTextures = (s: AppState) =>
+  s.modelData.hasCompressedTextures;
+
 export const selectModelCount = createSelector(
   selectStageModels,
   (models) => models.length

--- a/src/store/stage-data/exportTextureFile.ts
+++ b/src/store/stage-data/exportTextureFile.ts
@@ -6,6 +6,7 @@ import rgbaToArgb1555 from '@/utils/textures/serialize/rgbaToArgb1555';
 import rgbaToArgb4444 from '@/utils/textures/serialize/rgbaToArgb4444';
 import { RgbaColor, TextureColorFormat } from '@/utils/textures';
 import loadImageFromDataUrl from '@/utils/images/loadImageFromDataUrl';
+import { compressTextureBuffer } from '@/utils/textures/parse';
 
 /**
  * gets rotated pixels from a provided dataUrl string
@@ -46,7 +47,8 @@ const conversionDict: Record<TextureColorFormat, (color: RgbaColor) => number> =
 
 export default async function exportTextureFile(
   textureDefs: NLTextureDef[],
-  textureFileName = ''
+  textureFileName = '',
+  hasCompressedTextures: boolean
 ): Promise<void> {
   const { textureBuffer } = nonSerializables;
   if (!textureBuffer) {
@@ -79,7 +81,11 @@ export default async function exportTextureFile(
     }
   }
 
-  const output = new Blob([textureBuffer], {
+  const outputBuffer = !hasCompressedTextures
+    ? textureBuffer
+    : compressTextureBuffer(textureBuffer);
+
+  const output = new Blob([outputBuffer], {
     type: 'application/octet-stream'
   });
   const link = document.createElement('a');

--- a/src/utils/textures/parse/compressTextureBuffer.ts
+++ b/src/utils/textures/parse/compressTextureBuffer.ts
@@ -1,35 +1,79 @@
 const WORD_SIZE = 2;
-const COMPRESSION_FLAG = 0b1000000000000000;
+const COMPRESSION_FLAG = 0b1000_0000_0000_0000;
 
 export default function compressTextureBuffer(buffer: Buffer) {
   const output: number[] = [];
-  const bitmask = 0b0;
   let chunk = 0;
 
-  for (let i = 0; i < buffer.length / WORD_SIZE; i++) {
+  const valueInstanceMap = new Map<number, number>();
+
+  const processedFirstChunk = false;
+
+  let i = 0;
+  while (i < buffer.length / WORD_SIZE) {
     const value = buffer.readUInt16LE(i * WORD_SIZE);
 
-    let repetitions = 0;
+    let repetitions = 1;
 
-    // look ahead for repetitions in the current value scanned
-    while (buffer.readUInt16LE((i + repetitions) * WORD_SIZE) !== value) {
+    // discover repetitions in next bytes read
+    // being equal in decompressed buffer
+    while (
+      i + repetitions < buffer.length / WORD_SIZE &&
+      buffer.readUInt16LE((i + repetitions) * WORD_SIZE) === value
+    ) {
       repetitions++;
     }
 
-    if (repetitions) {
-      // flag to indicate there is compression
-      output.push(COMPRESSION_FLAG >> chunk);
+        console.log(
+          `@0x${(output.length * 2).toString(16)}, output will not be consumed`
+        );
 
-      // @TODO reverse the logic to unwrap repeat values
+      // special case where chunk advances
+      chunk++;
+      continue;
     }
 
-    // advance pointer by repetitions
+    // only repeats once, so store value
+    // directly
+    if (repetitions === 1) {
+      for (let j = 0; j < repetitions; j++) {
+        output.push(value);
+      }
+    }
+
+    if (repetitions > 2) {
+      // 32-bit compression
+      // as repetitions do not fit within 5bit mask
+
+      if (output.length < 100) {
+        console.log(
+          `@0x${(output.length * 2).toString(
+            16
+          )}, output has a compression flag`
+        );
+      }
+
+      // mark compression bit based on chunk #
+      output.push(COMPRESSION_FLAG >> chunk % 16);
+
+      if (repetitions <= 0b11111) {
+        // 16-bit
+        // the number of words to grab are stored in 5 msb
+        const repetitionBits = repetitions << 11;
+        // the number of words to go back is stored in 11LSB
+        const wordsBackCount = repetitions & 0b0111_1111_1111;
+
+        output.push(repetitionBits | wordsBackCount);
+      } else {
+        // 32-bit
+        output.push(repetitions & (0xffff << 16));
+
+        output.push(repetitions & 0xffff);
+      }
+    }
+
     i += repetitions;
     chunk++;
-
-    if (chunk === WORD_SIZE * 8) {
-      chunk = 0;
-    }
   }
 
   const outputBuffer = Buffer.alloc(output.length * WORD_SIZE);

--- a/src/utils/textures/parse/compressTextureBuffer.ts
+++ b/src/utils/textures/parse/compressTextureBuffer.ts
@@ -1,4 +1,10 @@
+// NOTE: this compression logic is a WIP/not actively consumed
+// in the application yet. Will revisit algo as it must support
+// repeated sequences between 2 to 31 words
+
 const WORD_SIZE = 2;
+
+/** starts at F000 and shifted for a mask check based on the chunk */
 const COMPRESSION_FLAG = 0b1000_0000_0000_0000;
 
 export default function compressTextureBuffer(buffer: Buffer) {
@@ -6,8 +12,6 @@ export default function compressTextureBuffer(buffer: Buffer) {
   let chunk = 0;
 
   const valueInstanceMap = new Map<number, number>();
-
-  const processedFirstChunk = false;
 
   let i = 0;
   while (i < buffer.length / WORD_SIZE) {
@@ -24,19 +28,14 @@ export default function compressTextureBuffer(buffer: Buffer) {
       repetitions++;
     }
 
-        console.log(
-          `@0x${(output.length * 2).toString(16)}, output will not be consumed`
-        );
-
-      // special case where chunk advances
-      chunk++;
-      continue;
-    }
-
     // only repeats once, so store value
     // directly
-    if (repetitions === 1) {
+    if (repetitions <= 2) {
       for (let j = 0; j < repetitions; j++) {
+        if (chunk++ % 16 === 0) {
+          // store first value saying chunk is not compressed
+          output.push(0);
+        }
         output.push(value);
       }
     }
@@ -45,11 +44,14 @@ export default function compressTextureBuffer(buffer: Buffer) {
       // 32-bit compression
       // as repetitions do not fit within 5bit mask
 
-      if (output.length < 100) {
+      if (output.length < 60) {
         console.log(
           `@0x${(output.length * 2).toString(
             16
-          )}, output has a compression flag`
+          )} will have compression flag written: 0b${(
+            COMPRESSION_FLAG >>
+            chunk % 16
+          ).toString(2)} for ${repetitions} repeated words of ${value}`
         );
       }
 
@@ -58,9 +60,9 @@ export default function compressTextureBuffer(buffer: Buffer) {
 
       if (repetitions <= 0b11111) {
         // 16-bit
-        // the number of words to grab are stored in 5 msb
+        // the number of words to grab are stored in 5 MSb
         const repetitionBits = repetitions << 11;
-        // the number of words to go back is stored in 11LSB
+        // the number of words to go back is stored in 11LSb
         const wordsBackCount = repetitions & 0b0111_1111_1111;
 
         output.push(repetitionBits | wordsBackCount);
@@ -70,10 +72,10 @@ export default function compressTextureBuffer(buffer: Buffer) {
 
         output.push(repetitions & 0xffff);
       }
+      chunk++;
     }
 
     i += repetitions;
-    chunk++;
   }
 
   const outputBuffer = Buffer.alloc(output.length * WORD_SIZE);

--- a/src/utils/textures/parse/compressTextureBuffer.ts
+++ b/src/utils/textures/parse/compressTextureBuffer.ts
@@ -1,0 +1,46 @@
+const WORD_SIZE = 2;
+
+export default function compressTextureBuffer(buffer: Buffer) {
+  const output: number[] = [];
+  let bitmask = 0b0;
+  let chunk = 0;
+  let wordsBackCount = 0;
+
+  for (let i = 0; i < buffer.length / WORD_SIZE; i++) {
+    const value = buffer.readUInt16LE(i * WORD_SIZE);
+
+    if (chunk === 0) {
+      output.push(bitmask);
+      bitmask = 0b0;
+    }
+
+    if (wordsBackCount > 0) {
+      output.push((wordsBackCount << 11) | (wordsBackCount - 1));
+      wordsBackCount--;
+    } else {
+      output.push(value);
+    }
+
+    const isCompressed = value === output[output.length - 1];
+
+    bitmask |= (isCompressed ? 1 : 0) << (0x0f - chunk);
+
+    chunk++;
+    if (chunk === 0x10) {
+      chunk = 0;
+    }
+
+    if (isCompressed) {
+      const repeatCount = Math.min(i, 0x0fff);
+      wordsBackCount = repeatCount;
+    }
+  }
+
+  const outputBuffer = Buffer.alloc(output.length * WORD_SIZE);
+
+  for (let i = 0; i < output.length; i++) {
+    outputBuffer.writeUInt16LE(output[i], i * WORD_SIZE);
+  }
+
+  return outputBuffer;
+}

--- a/src/utils/textures/parse/compressTextureBuffer.ts
+++ b/src/utils/textures/parse/compressTextureBuffer.ts
@@ -1,43 +1,38 @@
 const WORD_SIZE = 2;
+const COMPRESSION_FLAG = 0b1000000000000000;
 
 export default function compressTextureBuffer(buffer: Buffer) {
   const output: number[] = [];
-  let bitmask = 0b0;
+  const bitmask = 0b0;
   let chunk = 0;
-  let wordsBackCount = 0;
 
   for (let i = 0; i < buffer.length / WORD_SIZE; i++) {
     const value = buffer.readUInt16LE(i * WORD_SIZE);
 
-    if (chunk === 0) {
-      output.push(bitmask);
-      bitmask = 0b0;
+    let repetitions = 0;
+
+    // look ahead for repetitions in the current value scanned
+    while (buffer.readUInt16LE((i + repetitions) * WORD_SIZE) !== value) {
+      repetitions++;
     }
 
-    if (wordsBackCount > 0) {
-      output.push((wordsBackCount << 11) | (wordsBackCount - 1));
-      wordsBackCount--;
-    } else {
-      output.push(value);
+    if (repetitions) {
+      // flag to indicate there is compression
+      output.push(COMPRESSION_FLAG >> chunk);
+
+      // @TODO reverse the logic to unwrap repeat values
     }
 
-    const isCompressed = value === output[output.length - 1];
-
-    bitmask |= (isCompressed ? 1 : 0) << (0x0f - chunk);
-
+    // advance pointer by repetitions
+    i += repetitions;
     chunk++;
-    if (chunk === 0x10) {
-      chunk = 0;
-    }
 
-    if (isCompressed) {
-      const repeatCount = Math.min(i, 0x0fff);
-      wordsBackCount = repeatCount;
+    if (chunk === WORD_SIZE * 8) {
+      chunk = 0;
     }
   }
 
   const outputBuffer = Buffer.alloc(output.length * WORD_SIZE);
-
   for (let i = 0; i < output.length; i++) {
     outputBuffer.writeUInt16LE(output[i], i * WORD_SIZE);
   }

--- a/src/utils/textures/parse/decompressTextureBuffer.ts
+++ b/src/utils/textures/parse/decompressTextureBuffer.ts
@@ -75,11 +75,6 @@ export default function decompressTextureBuffer(buffer: Buffer) {
 
   const outputBuffer = Buffer.from(new Uint8Array(output.length * 2));
 
-  // we were working with 16-bit unsigned integers as source abstraction
-  // for convenience, so need to split up the bytes again since JS API
-  // Uint16Array does not store 16-bit values into buffer (instead will
-  // truncate to 8-bit in the Buffer)
-
   for (let i = 0; i < output.length; i++) {
     outputBuffer.writeUInt16LE(output[i], i * WORD_SIZE);
   }

--- a/src/utils/textures/parse/index.ts
+++ b/src/utils/textures/parse/index.ts
@@ -1,3 +1,4 @@
+export { default as compressTextureBuffer } from './compressTextureBuffer';
 export { default as decompressTextureBuffer } from './decompressTextureBuffer';
 export { default as argb1555ToRgba8888 } from './argb1555ToRgba8888';
 export { default as argb4444ToRgba8888 } from './argb4444ToRgba8888';


### PR DESCRIPTION
Begin supporting compressed textures by tracking relevant state. Compression logic is WIP but needs some reverse engineering to get the exact format so that file lengths match up with originals; in the meantime GUI is modified so that export is not possible on games where textures need to be recompressed so that it is clear what the app supports. Minor optimization also provided for decompression since 16 bit words were split manually into a native byte buffer (vs writeInt16LE which I was not aware of when first working on this).