### PR TITLE
update texture selection appearance, consistent theme

### DIFF
--- a/src/components/panel/GuiPanel.tsx
+++ b/src/components/panel/GuiPanel.tsx
@@ -264,12 +264,7 @@ export default function GuiPanel() {
             textureDef={textureDef}
             textureIndex={m.textureIndex}
             textureSize={m.textureSize}
-            isDeemphasized={
-              !(
-                selectedMeshTexture === -1 ||
-                selectedMeshTexture === m.textureIndex
-              )
-            }
+            selected={selectedMeshTexture === m.textureIndex}
           />
         );
       }

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -13,10 +13,6 @@ const StyledPanelTexture = styled('div')(
       width: 100%;
       background-color: ${theme.palette.panelTexture.background};
   }
-
-  & .MuiTypography-root {
-    opacity: 0.5;
-  }
       
   & .image-area {
     position: relative;
@@ -48,8 +44,9 @@ const StyledPanelTexture = styled('div')(
     position: absolute;
     right: ${theme.spacing(1)};
     bottom: 0;
-    color: #fff;
+    color: ${theme.palette.primary.contrastText};
     text-shadow: 1px 1px 1px black;
+    filter: drop-shadow(3px 3px 1px black);
   }
   `
 );
@@ -86,7 +83,7 @@ export default function GuiPanelTexture({
           textAlign='right'
           className={'size-notation'}
         >
-          {textureSize[0]}x{textureSize[0]} [index: {textureIndex}]
+          {textureSize[0]}x{textureSize[0]} [{textureIndex}]
         </Typography>
         <GuiPanelTextureMenu textureIndex={textureIndex} dataUrl={dataUrl} />
       </div>

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -14,7 +14,7 @@ const StyledPanelTexture = styled('div')(
       background-color: ${theme.palette.panelTexture.background};
   }
 
-  & .MuiTypography-root.deemphasized {
+  & .MuiTypography-root {
     opacity: 0.5;
   }
       
@@ -34,16 +34,14 @@ const StyledPanelTexture = styled('div')(
   & img {
     width: 100%;
     height: auto;
-    border-color: ${theme.palette.secondary.main};
-    border-width: 1px;
+    border-color: transparent;
+    border-width: 2px;
     border-style: solid;
     opacity: 1.0;
-    transition: opacity 0.35s ease;
   }
 
-  & img.deemphasized {
-    filter: saturate(0.5);
-    opacity: 0.25;
+  & .selected img {
+    border-color: ${theme.palette.primary.main};
   }
 
   & .size-notation {
@@ -53,22 +51,18 @@ const StyledPanelTexture = styled('div')(
     color: #fff;
     text-shadow: 1px 1px 1px black;
   }
-
-  & .size-notation.deemphasized {
-    filter: invert(1);
-  }
   `
 );
 
 export type GuiPanelTextureProps = {
-  isDeemphasized: boolean;
+  selected: boolean;
   textureDef: NLTextureDef;
   textureSize: TextureSize;
   textureIndex: number;
 };
 
 export default function GuiPanelTexture({
-  isDeemphasized,
+  selected,
   textureIndex,
   textureDef,
   textureSize
@@ -77,23 +71,20 @@ export default function GuiPanelTexture({
   const dataUrl =
     textureDef.dataUrls.opaque || textureDef.dataUrls.translucent || '';
 
-  const deemphasizedClass = clsx(isDeemphasized && 'deemphasized');
-
   return (
     <StyledPanelTexture>
-      <div className='image-area'>
+      <div className={clsx(selected && 'selected', 'image-area')}>
         <Image
           src={dataUrl}
           id={`debug-panel-t-${textureIndex}`}
           alt={`Texture # ${textureIndex}`}
           width={Number(width)}
           height={Number(height)}
-          className={deemphasizedClass}
         />
         <Typography
           variant='subtitle2'
           textAlign='right'
-          className={clsx(deemphasizedClass, 'size-notation')}
+          className={'size-notation'}
         >
           {textureSize[0]}x{textureSize[0]} [index: {textureIndex}]
         </Typography>

--- a/src/components/panel/textures/GuiPanelTextureMenu.tsx
+++ b/src/components/panel/textures/GuiPanelTextureMenu.tsx
@@ -17,7 +17,7 @@ const StyledMenuButtonContainer = styled('div')(
     }
 
     & .MuiIconButton-root svg {
-        color: #fff;
+        color: ${theme.palette.primary.contrastText};
         filter: drop-shadow(3px 5px 2px rgb(0 0 0 / 0.8));
     }
     `

--- a/src/theming/themes.ts
+++ b/src/theming/themes.ts
@@ -71,7 +71,7 @@ const themes = Object.fromEntries(
         },
         sceneMesh: {
           default: mode === 'dark' ? '#683C62' : '#AAC',
-          selected: mode === 'dark' ? '#00A5FF' : '#e98df5',
+          selected: mode === 'dark' ? '#FF00F2' : '#e98df5',
           flagged: '#9BF',
           textureDefault: '#fff',
           textureSelected: mode === 'dark' ? '#9cf' : '#f9c'

--- a/src/theming/themes.ts
+++ b/src/theming/themes.ts
@@ -52,6 +52,15 @@ const themes = Object.fromEntries(
       typography: {
         fontFamily: firaCode.style.fontFamily
       },
+      components: {
+        MuiListSubheader: {
+          styleOverrides: {
+            root: {
+              backgroundColor: 'inherit'
+            }
+          }
+        }
+      },
       palette: {
         mode,
         primary: {


### PR DESCRIPTION
GUI changes for updated workflow with HSL in texture menu:

- no longer desaturate unhighlighted textures since it helps to see textures with their natural colors
- use a simple hotpink texture highlight color pink to correspond to selections throughout app
- improve appearance of texture size annotation

![image](https://github.com/rob2d/modnao/assets/1799905/f5bf24d4-9101-4ce2-8b7b-22f603784b6a)
