### PR TITLE
continuous model nav control with keyboard or buttons

### DIFF
--- a/src/components/scene/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/store/selectors';
 import { useAppSelector, useAppDispatch, setObjectKey } from '@/store';
 import RenderedMesh from './RenderedMesh';
-import { useSceneKeyboardActions } from '@/hooks';
+import { useSceneKeyboardControls } from '@/hooks';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import { useTheme } from '@mui/material';
 import { SceneContextSetup } from '@/contexts/SceneContext';
@@ -33,7 +33,7 @@ THREE.ColorManagement.enabled = true;
 const cameraParams = { far: 5000000 };
 
 export default function SceneCanvas() {
-  useSceneKeyboardActions();
+  useSceneKeyboardControls();
   const canvasRef = useRef() as MutableRefObject<HTMLCanvasElement>;
   const viewOptions = useContext(ViewOptionsContext);
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,3 @@
 export { default as useAsyncDispatchOnMount } from './useAsyncDispatchOnMount';
-export { default as useSceneKeyboardActions } from './useSceneKeyboardActions';
+export { default as useSceneKeyboardControls } from './useSceneKeyboardControls';
 export { default as useModelSelectionExport } from './useModelSelectionExport';

--- a/src/hooks/useSceneKeyboardControls.ts
+++ b/src/hooks/useSceneKeyboardControls.ts
@@ -6,7 +6,7 @@ import { setModelViewedIndex } from '@/store';
 import { AnyAction } from '@reduxjs/toolkit';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 
-export default function useSceneKeyboardActions() {
+export default function useSceneKeyboardControls() {
   const dispatch = useDispatch();
   const viewOptions = useContext(ViewOptionsContext);
   const modelIndex = useSelector(selectModelIndex);

--- a/src/hooks/useSceneKeyboardControls.ts
+++ b/src/hooks/useSceneKeyboardControls.ts
@@ -1,30 +1,67 @@
-import { useContext, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import { useKeyPress } from '@react-typed-hooks/use-key-press';
-import { selectModelCount, selectModelIndex } from '@/store/selectors';
-import { setModelViewedIndex } from '@/store';
+import { navToNextModel, navToPrevModel } from '@/store';
 import { AnyAction } from '@reduxjs/toolkit';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
+
+function useHeldRepetitionTimer(): [(action: () => void) => void, () => void] {
+  const timeout = useRef<NodeJS.Timeout | null>(null);
+
+  const disengageAction = useCallback(() => {
+    if (timeout.current) {
+      clearTimeout(timeout.current);
+    }
+  }, []);
+
+  const engageRepeatedAction = useCallback((action: () => void) => {
+    let delay = 400;
+    const processAction = () => {
+      action();
+      timeout.current = setTimeout(processAction, delay);
+      if (delay > 100) {
+        delay -= 50;
+      } else if (delay > 50) {
+        delay -= 25;
+      } else if (delay > 10) {
+        delay -= 5;
+      }
+    };
+
+    processAction();
+  }, []);
+
+  return [engageRepeatedAction, disengageAction];
+}
 
 export default function useSceneKeyboardControls() {
   const dispatch = useDispatch();
   const viewOptions = useContext(ViewOptionsContext);
-  const modelIndex = useSelector(selectModelIndex);
-  const modelCount = useSelector(selectModelCount);
   const isLeftPressed = useKeyPress({ targetKey: 'ArrowLeft' });
   const isRightPressed = useKeyPress({ targetKey: 'ArrowRight' });
   const isControlPressed = useKeyPress({ targetKey: 'Control' });
   const isSlashPressed = useKeyPress({ targetKey: '\\' });
 
+  const [onStartPrevModelNav, onStopPrevModelNav] = useHeldRepetitionTimer();
+  const [onStartNextModelNav, onStopNextModelNav] = useHeldRepetitionTimer();
+
   useEffect(() => {
-    if (isLeftPressed && modelIndex > 0) {
-      dispatch(setModelViewedIndex(modelIndex - 1) as unknown as AnyAction);
+    if (isLeftPressed) {
+      onStartPrevModelNav(() => {
+        dispatch(navToPrevModel() as unknown as AnyAction);
+      });
+    } else {
+      onStopPrevModelNav();
     }
   }, [isLeftPressed]);
 
   useEffect(() => {
-    if (isRightPressed && modelIndex < modelCount - 1) {
-      dispatch(setModelViewedIndex(modelIndex + 1) as unknown as AnyAction);
+    if (isRightPressed) {
+      onStartNextModelNav(() => {
+        dispatch(navToNextModel() as unknown as AnyAction);
+      });
+    } else {
+      onStopNextModelNav();
     }
   }, [isRightPressed]);
 

--- a/src/store/modelViewerSlice.ts
+++ b/src/store/modelViewerSlice.ts
@@ -23,7 +23,11 @@ const sliceName = 'modelViewer';
  * interfacing action for actual setModelViewedIndex
  * for toolkit thunk api access
  */
-export const setModelViewedIndex = createAsyncThunk<void, number>(
+export const setModelViewedIndex = createAsyncThunk<
+  void,
+  number,
+  { state: AppState }
+>(
   `${sliceName}/setModelViewedIndexInterface`,
   async (nextIndex: number, { dispatch, getState }) => {
     let modelIndex = Math.max(0, nextIndex);
@@ -34,6 +38,31 @@ export const setModelViewedIndex = createAsyncThunk<void, number>(
     dispatch(actions.setModelViewedIndex(modelIndex));
   }
 );
+
+export const navToNextModel = createAsyncThunk<
+  void,
+  undefined,
+  { state: AppState }
+>(`${sliceName}/navToNextModel`, async (_, { dispatch, getState }) => {
+  const state = getState();
+  const modelCount = state.modelData.models.length;
+  const modelIndex = Math.min(state.modelViewer.modelIndex + 1, modelCount - 1);
+
+  const { actions } = modelViewerSlice;
+  dispatch(actions.setModelViewedIndex(modelIndex));
+});
+
+export const navToPrevModel = createAsyncThunk<
+  void,
+  undefined,
+  { state: AppState }
+>(`${sliceName}/navToPrevModel`, async (_, { dispatch, getState }) => {
+  const state = getState();
+  const modelIndex = Math.max(state.modelViewer.modelIndex - 1, 0);
+
+  const { actions } = modelViewerSlice;
+  dispatch(actions.setModelViewedIndex(modelIndex));
+});
 
 const modelViewerSlice = createSlice({
   name: 'modelViewer',


### PR DESCRIPTION
Adds a spin-number input esque behavior for model navigation since the newly supported `DM01` models on Marvel vs Capcom 2 have quite a lot of models/it gets tedious to navigate through manually

[thanks to @DJClayface for bringing this up to address it immediately]

![model-spin-nav-behavior_edit_0](https://github.com/rob2d/modnao/assets/1799905/fe15f4a5-0a7a-4a41-8648-c11c66702183)
