### PR TITLE
optimize texture edit pipeline and provide pre-multiplied alpha workaround

### DIFF
--- a/src/components/scene/RenderedMesh.tsx
+++ b/src/components/scene/RenderedMesh.tsx
@@ -1,7 +1,12 @@
 import RenderedPolygon from './RenderedPolygon';
 import { NLTextureDef } from '@/types/NLAbstractions';
 import { useTexture } from '@react-three/drei';
-import { ClampToEdgeWrapping, RepeatWrapping, sRGBEncoding } from 'three';
+import {
+  ClampToEdgeWrapping,
+  RepeatWrapping,
+  sRGBEncoding,
+  Vector2
+} from 'three';
 
 type RenderedMeshProps = {
   objectKey: string;
@@ -12,6 +17,9 @@ type RenderedMeshProps = {
 } & NLMesh;
 
 const transparent1x1 = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==`;
+
+const TEXTURE_ROTATION = (90 * Math.PI) / 180;
+const TEXTURE_CENTER = new Vector2(0.5, 0.5);
 
 export default function RenderedMesh({
   objectKey,
@@ -28,6 +36,8 @@ export default function RenderedMesh({
   const texture = useTexture(
     textureDef?.dataUrls[isOpaque ? 'opaque' : 'translucent'] || transparent1x1
   );
+  texture.rotation = TEXTURE_ROTATION;
+  texture.center = TEXTURE_CENTER;
 
   // addresses an issue in ThreeJS with
   // sRGB randomly not applying to textures depending

--- a/src/store/model-data/storeSourceTextureData.ts
+++ b/src/store/model-data/storeSourceTextureData.ts
@@ -16,24 +16,18 @@ export default async function storeSourceTextureData(
     const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
     ctx.drawImage(image, 0, 0);
 
-    const rotatedCanvas = document.createElement('canvas');
-    rotatedCanvas.width = width;
-    rotatedCanvas.height = height;
-    const rotatedCtx = rotatedCanvas.getContext(
-      '2d'
-    ) as CanvasRenderingContext2D;
-
-    rotatedCtx.translate(canvas.width / 2, canvas.height / 2);
-
-    rotatedCtx.rotate((90 * Math.PI) / 180);
-    rotatedCtx.drawImage(canvas, -canvas.width / 2, -canvas.height / 2);
-
-    const imageData = rotatedCtx.getImageData(0, 0, width, height);
+    const imageData = ctx.getImageData(0, 0, width, height);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.translate(canvas.width / 2, canvas.height / 2);
+    ctx.rotate((90 * Math.PI) / 180);
+    const createdData = await createImageBitmap(imageData);
+    ctx.drawImage(createdData, -canvas.width / 2, -canvas.height / 2);
+    const rotatedImageData = ctx.getImageData(0, 0, width, height);
 
     // @TODO process both translucent and opaque data variants
     nonSerializables.sourceTextureData[textureIndex] = {
-      opaque: imageData,
-      translucent: imageData
+      opaque: rotatedImageData,
+      translucent: rotatedImageData
     };
   }
 }

--- a/src/store/model-data/storeSourceTextureData.ts
+++ b/src/store/model-data/storeSourceTextureData.ts
@@ -17,17 +17,11 @@ export default async function storeSourceTextureData(
     ctx.drawImage(image, 0, 0);
 
     const imageData = ctx.getImageData(0, 0, width, height);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.translate(canvas.width / 2, canvas.height / 2);
-    ctx.rotate((90 * Math.PI) / 180);
-    const createdData = await createImageBitmap(imageData);
-    ctx.drawImage(createdData, -canvas.width / 2, -canvas.height / 2);
-    const rotatedImageData = ctx.getImageData(0, 0, width, height);
 
     // @TODO process both translucent and opaque data variants
     nonSerializables.sourceTextureData[textureIndex] = {
-      opaque: rotatedImageData,
-      translucent: rotatedImageData
+      opaque: imageData,
+      translucent: imageData
     };
   }
 }

--- a/src/utils/color-conversions/adjustHslOfRgba.ts
+++ b/src/utils/color-conversions/adjustHslOfRgba.ts
@@ -1,4 +1,3 @@
-import { RgbaColor } from '../textures';
 import hslToRgb from './hslToRgb';
 import rgbToHsl from './rgbToHsl';
 
@@ -7,19 +6,20 @@ function clamp(value: number, min: number, max: number) {
 }
 
 export default function adjustHslOfRgba(
-  rgba: RgbaColor,
+  r: number,
+  g: number,
+  b: number,
   h: number,
   s: number,
   l: number
 ) {
-  const hsl = rgbToHsl(rgba.r, rgba.g, rgba.b);
-  const color: RgbaColor = {
-    ...hslToRgb({
-      h: (h + hsl.h) % 360,
-      s: clamp(hsl.s + s, 0, 100),
-      l: clamp(hsl.l + l, -100, 100)
-    }),
-    a: rgba.a
+  const hsl = rgbToHsl(r, g, b);
+  const color = {
+    ...hslToRgb(
+      (h + hsl.h) % 360,
+      clamp(hsl.s + s, 0, 100),
+      clamp(hsl.l + l, -100, 100)
+    )
   };
   return color;
 }

--- a/src/utils/color-conversions/hslToRgb.ts
+++ b/src/utils/color-conversions/hslToRgb.ts
@@ -20,7 +20,7 @@ const hueToRgb = (p: number, q: number, t: number) => {
   return p;
 };
 
-export default function hslToRgb({ h, s, l }: HslValues) {
+export default function hslToRgb(h: number, s: number, l: number) {
   h /= 360;
   s /= 100;
   l /= 100;

--- a/src/utils/textures/adjustTextureHsl.ts
+++ b/src/utils/textures/adjustTextureHsl.ts
@@ -52,12 +52,8 @@ export default async function adjustTextureHsl(
     data[i + 3] = sourceData[i + 3];
   }
 
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.translate(canvas.width / 2, canvas.height / 2);
-  ctx.rotate((-90 * Math.PI) / 180);
-
   const createdData = await createImageBitmap(imageData);
-  ctx.drawImage(createdData, -canvas.width / 2, -canvas.height / 2);
+  ctx.drawImage(createdData, 0, 0);
 
   const dataUrl = await offscreenCanvasToDataUrl(canvas);
   return dataUrl;

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -22,15 +22,14 @@ async function getPixelsFromDataUrlImage(dataUrl: string) {
   const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
   ctx.drawImage(image, 0, 0);
 
-  const rotatedCanvas = document.createElement('canvas');
-  rotatedCanvas.width = width;
-  rotatedCanvas.height = height;
-  const rotatedCtx = rotatedCanvas.getContext('2d') as CanvasRenderingContext2D;
-  rotatedCtx.translate(canvas.width / 2, canvas.height / 2);
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.translate(canvas.width / 2, canvas.height / 2);
+  ctx.rotate((90 * Math.PI) / 180);
 
-  rotatedCtx.rotate((90 * Math.PI) / 180);
-  rotatedCtx.drawImage(canvas, -canvas.width / 2, -canvas.height / 2);
-  const imageData = rotatedCtx.getImageData(0, 0, width, height);
+  const createdData = await createImageBitmap(imageData);
+  ctx.drawImage(createdData, -canvas.width / 2, -canvas.height / 2);
+
   return imageData.data;
 }
 

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -47,6 +47,7 @@ export default async function exportTextureFile(
     return;
   }
 
+  let i = 0;
   for await (const t of textureDefs) {
     const { baseLocation, ramOffset, width, height } = t;
 
@@ -65,6 +66,16 @@ export default async function exportTextureFile(
           a: pixelColors[colorOffset + 3]
         };
 
+        // workaround in interrim of black colors in scenario where rgb
+        // that get lost on premultiplied alpha: preserve the source texture
+        // rgb colors when alpha is zero
+        if (color.a === 0) {
+          const o = nonSerializables.sourceTextureData[i].translucent.data;
+          color.r = o[colorOffset];
+          color.g = o[colorOffset + 1];
+          color.b = o[colorOffset + 2];
+        }
+
         const conversionOp = conversionDict[t.colorFormat];
         const offsetWritten = baseLocation - ramOffset + offset * COLOR_SIZE;
 
@@ -75,6 +86,7 @@ export default async function exportTextureFile(
         }
       }
     }
+    i++;
   }
 
   const outputBuffer = !hasCompressedTextures

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -23,13 +23,6 @@ async function getPixelsFromDataUrlImage(dataUrl: string) {
   ctx.drawImage(image, 0, 0);
 
   const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.translate(canvas.width / 2, canvas.height / 2);
-  ctx.rotate((90 * Math.PI) / 180);
-
-  const createdData = await createImageBitmap(imageData);
-  ctx.drawImage(createdData, -canvas.width / 2, -canvas.height / 2);
-
   return imageData.data;
 }
 

--- a/src/utils/textures/parse/processTextureBuffer.ts
+++ b/src/utils/textures/parse/processTextureBuffer.ts
@@ -83,16 +83,7 @@ export default async function processTextureBuffer(
       };
       sourceTextureData[i][dataUrlType] = id;
 
-      const canvas2 = new OffscreenCanvas(canvas.width, canvas.height);
-
-      const context2 = canvas2.getContext(
-        '2d'
-      ) as OffscreenCanvasRenderingContext2D;
-      context2.translate(canvas.width / 2, canvas.height / 2);
-      context2.rotate((-90 * Math.PI) / 180);
-      context2.drawImage(canvas, -canvas.width / 2, -canvas.height / 2);
-
-      const dataUrl = await offscreenCanvasToDataUrl(canvas2);
+      const dataUrl = await offscreenCanvasToDataUrl(canvas);
 
       updatedTexture.dataUrls = {
         ...updatedTexture.dataUrls,


### PR DESCRIPTION
Cuts out a lot of operations and memory allocation for objects during texture conversions. Also provides a workaround for pre-multiplied alpha on desert stage and in some menus destroying color data on-edit.