### PR TITLE
Feature/integrate thunks and threads

### DIFF
--- a/src/store/storeActionsWorker.ts
+++ b/src/store/storeActionsWorker.ts
@@ -1,6 +1,5 @@
 import { store } from './store';
 import {
-  adjustTextureHslFromThread,
   LoadPolygonsPayload,
   loadTexturesFromWorker,
   LoadTexturesPayload
@@ -39,17 +38,13 @@ export const workerMessageHandler = async (
   event: MessageEvent<WorkerResponses>
 ) => {
   switch (event.data.type) {
+    case 'adjustTextureHsl':
     case 'loadPolygonFile': {
       break;
     }
     case 'loadTextureFile': {
       const { result } = event.data;
       store.dispatch(loadTexturesFromWorker(result));
-      break;
-    }
-    case 'adjustTextureHsl': {
-      const { result } = event.data;
-      store.dispatch(adjustTextureHslFromThread(result));
       break;
     }
   }

--- a/src/store/storeActionsWorker.ts
+++ b/src/store/storeActionsWorker.ts
@@ -1,10 +1,10 @@
 import { store } from './store';
 import {
+  AdjustTextureHslPayload,
   LoadPolygonsPayload,
   loadTexturesFromWorker,
   LoadTexturesPayload
 } from './modelDataSlice';
-import HslValues from '@/utils/textures/HslValues';
 export type LoadPolygonsResult = {
   type: 'loadPolygonFile';
   result: LoadPolygonsPayload;
@@ -15,17 +15,15 @@ export type LoadTexturesResult = {
   result: LoadTexturesPayload;
 };
 
+export type AdjustTextureHslResult = {
+  type: 'adjustTextureHsl';
+  result: AdjustTextureHslPayload;
+};
+
 export type WorkerResponses =
   | LoadPolygonsResult
   | LoadTexturesResult
-  | {
-      type: 'adjustTextureHsl';
-      result: {
-        textureIndex: number;
-        hsl: HslValues;
-        bufferUrls: { translucent: string; opaque: string };
-      };
-    };
+  | AdjustTextureHslResult;
 
 export const createWorker = () =>
   !globalThis.Worker


### PR DESCRIPTION
partially addresses #77 , for `adjustTextureHsl` thunk/worker ops.

Apply all HSL changes have a significant performance boost when textures are all on their own thread, so worth merging early in this case.

![image](https://github.com/rob2d/modnao/assets/1799905/d1fe1318-7595-45df-8c01-cfcfffc52abd)
