### PR TITLE
pre-load texture dataUrls for texture panel in loadTexture threads

### DIFF
--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import { useSelector } from 'react-redux';
-import { Image } from 'image-js';
-import Img from 'next/image';
+import Image from 'next/image';
 import { useDropzone } from 'react-dropzone';
 import { Skeleton, styled, Typography } from '@mui/material';
 import { NLTextureDef } from '@/types/NLAbstractions';
@@ -11,7 +10,7 @@ import {
   selectIsMeshOpaque,
   useAppDispatch
 } from '@/store';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { bufferToObjectUrl, objectUrlToBuffer } from '@/utils/data';
 import loadRGBABuffersFromFile from '@/utils/images/loadRGBABufferFromFile';
 
@@ -144,30 +143,12 @@ export default function GuiPanelTexture({
 
   const { width, height } = textureDef;
 
-  const [imgSrc, setImgSrc] = useState<string>('');
-
   // if there's a currently selected mesh and it's opaque, prioritize opaque,
   // otherwise fallback to actionable dataUrl
-  const pixelDataUrl =
+  const imageDataUrl =
     (selected && isSelectedMeshOpaque
-      ? textureDef.bufferUrls.opaque || textureDef.bufferUrls.translucent
-      : textureDef.bufferUrls.translucent || textureDef.bufferUrls.opaque) ||
-    '';
-
-  useEffect(() => {
-    (async () => {
-      const pixels = new Uint8ClampedArray(
-        await objectUrlToBuffer(pixelDataUrl)
-      );
-
-      if (pixels.length === 0) {
-        return;
-      }
-
-      const dataUrl = new Image({ data: pixels, width, height }).toDataURL();
-      setImgSrc(dataUrl);
-    })();
-  }, [pixelDataUrl]);
+      ? textureDef.dataUrls.opaque || textureDef.dataUrls.translucent
+      : textureDef.dataUrls.translucent || textureDef.dataUrls.opaque) || '';
 
   return (
     <StyledPanelTexture>
@@ -180,11 +161,11 @@ export default function GuiPanelTexture({
         )}
         {...getRootProps()}
       >
-        {!imgSrc ? (
+        {!imageDataUrl ? (
           <Skeleton variant='rectangular' height={170} width='100%' />
         ) : (
-          <Img
-            src={imgSrc}
+          <Image
+            src={imageDataUrl}
             width={width}
             height={height}
             alt={`Texture # ${textureIndex}`}

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -69,15 +69,22 @@ export const selectSceneTextureDefs = createSelector(
   selectEditedTextures,
   (textureDefs, bufferUrlEntries): typeof textureDefs => {
     const returnTextures = [...textureDefs];
-    Object.entries(bufferUrlEntries).forEach(([index, { bufferUrls }]) => {
-      const i = Number.parseInt(index);
-      const entry = { ...returnTextures[i] };
-      entry.bufferUrls = {
-        ...entry.bufferUrls,
-        ...bufferUrls
-      };
-      returnTextures[i] = entry;
-    });
+    Object.entries(bufferUrlEntries).forEach(
+      ([index, { bufferUrls, dataUrls }]) => {
+        const i = Number.parseInt(index);
+        const entry = { ...returnTextures[i] };
+        entry.bufferUrls = {
+          ...entry.bufferUrls,
+          ...bufferUrls
+        };
+
+        entry.dataUrls = {
+          ...entry.dataUrls,
+          ...dataUrls
+        };
+        returnTextures[i] = entry;
+      }
+    );
 
     return returnTextures;
   }
@@ -125,15 +132,4 @@ export const selectIsMeshOpaque = createSelector(
   selectModel,
   selectObjectMeshIndex,
   (model, meshIndex) => model?.meshes[meshIndex]?.isOpaque
-);
-
-export const selectPixelDataUrls = createSelector(
-  selectTextureDefs,
-  async (textureDefs) => {
-    for await (const def of textureDefs) {
-      for await (const [type, url] of Object.entries(def.bufferUrls)) {
-        const pixels = new Uint8ClampedArray(await objectUrlToBuffer(url));
-      }
-    }
-  }
 );

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { AppState } from './store';
 import { SourceTextureData } from '@/utils/textures/SourceTextureData';
+import { objectUrlToBuffer } from '@/utils/data';
 
 export const selectModelIndex = (s: AppState) => s.modelViewer.modelIndex;
 
@@ -124,4 +125,15 @@ export const selectIsMeshOpaque = createSelector(
   selectModel,
   selectObjectMeshIndex,
   (model, meshIndex) => model?.meshes[meshIndex]?.isOpaque
+);
+
+export const selectPixelDataUrls = createSelector(
+  selectTextureDefs,
+  async (textureDefs) => {
+    for await (const def of textureDefs) {
+      for await (const [type, url] of Object.entries(def.bufferUrls)) {
+        const pixels = new Uint8ClampedArray(await objectUrlToBuffer(url));
+      }
+    }
+  }
 );

--- a/src/types/NLAbstractions.d.ts
+++ b/src/types/NLAbstractions.d.ts
@@ -96,4 +96,8 @@ export type NLTextureDef = {
     translucent?: string;
     opaque?: string;
   };
+  dataUrls: {
+    translucent?: string;
+    opaque?: string;
+  };
 } & ModNaoMemoryObject;

--- a/src/utils/textures/adjustTextureHsl.ts
+++ b/src/utils/textures/adjustTextureHsl.ts
@@ -1,9 +1,12 @@
+import { Image } from 'image-js';
 import adjustHslOfRgba from '../color-conversions/adjustHslOfRgba';
 import { bufferToObjectUrl, objectUrlToBuffer } from '../data';
 import HslValues from './HslValues';
 
 export default async function adjustTextureHsl(
   sourceUrl: string,
+  width: number,
+  height: number,
   hsl: HslValues
 ) {
   const { h, s, l } = hsl;
@@ -47,6 +50,15 @@ export default async function adjustTextureHsl(
     imageData[i + 3] = sourceData[i + 3];
   }
 
-  const dataUrl = await bufferToObjectUrl(imageData);
-  return dataUrl;
+  const objectUrl = await bufferToObjectUrl(imageData);
+  const dataUrl = new Image({
+    data: imageData,
+    width,
+    height
+  }).toDataURL();
+
+  return {
+    objectUrl,
+    dataUrl
+  };
 }

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -1,8 +1,8 @@
+import { Image } from 'image-js';
 import {
   decompressTextureBuffer,
   encodeZMortonPosition
 } from '@/utils/textures/parse';
-import { Image } from 'image-js';
 import { NLTextureDef, TextureDataUrlType } from '@/types/NLAbstractions';
 import {
   argb1555ToRgba8888,

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -2,6 +2,7 @@ import {
   decompressTextureBuffer,
   encodeZMortonPosition
 } from '@/utils/textures/parse';
+import { Image } from 'image-js';
 import { NLTextureDef, TextureDataUrlType } from '@/types/NLAbstractions';
 import {
   argb1555ToRgba8888,
@@ -30,12 +31,11 @@ async function loadTextureBuffer(
   const buffer = Buffer.from(bufferPassed);
   const nextTextureDefs: NLTextureDef[] = [];
 
-  let i = 0;
   for await (const t of textureDefs) {
     const urlTypes = Object.keys(t.bufferUrls) as TextureDataUrlType[];
     const updatedTexture = { ...t };
 
-    for await (const objectUrlType of urlTypes) {
+    for await (const type of urlTypes) {
       const pixels = new Uint8ClampedArray(t.width * t.height * 4);
 
       for (let y = 0; y < t.height; y++) {
@@ -59,8 +59,7 @@ async function loadTextureBuffer(
           pixels[canvasOffset] = color.r;
           pixels[canvasOffset + 1] = color.g;
           pixels[canvasOffset + 2] = color.b;
-          pixels[canvasOffset + 3] =
-            objectUrlType === 'translucent' ? color.a : 255;
+          pixels[canvasOffset + 3] = type === 'translucent' ? color.a : 255;
         }
       }
 
@@ -68,12 +67,22 @@ async function loadTextureBuffer(
 
       updatedTexture.bufferUrls = {
         ...updatedTexture.bufferUrls,
-        [objectUrlType]: objectUrl
+        [type]: objectUrl
+      };
+
+      const dataUrl = new Image({
+        data: pixels,
+        width: t.width,
+        height: t.height
+      }).toDataURL();
+
+      updatedTexture.dataUrls = {
+        ...updatedTexture.dataUrls,
+        [type]: dataUrl
       };
     }
 
     nextTextureDefs.push(updatedTexture);
-    i++;
   }
 
   return {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -52,8 +52,8 @@ addEventListener('message', async ({ data }: MessageEvent<WorkerEvent>) => {
       const { sourceTextureData, textureIndex, hsl, width, height } = payload;
 
       const [translucent, opaque] = await Promise.all([
-        adjustTextureHsl(sourceTextureData.translucent, hsl),
-        adjustTextureHsl(sourceTextureData.opaque, hsl)
+        adjustTextureHsl(sourceTextureData.translucent, width, height, hsl),
+        adjustTextureHsl(sourceTextureData.opaque, width, height, hsl)
       ]);
 
       postMessage({
@@ -63,7 +63,14 @@ addEventListener('message', async ({ data }: MessageEvent<WorkerEvent>) => {
           textureIndex,
           width,
           height,
-          bufferUrls: { translucent, opaque }
+          bufferUrls: {
+            translucent: translucent.objectUrl,
+            opaque: opaque.objectUrl
+          },
+          dataUrls: {
+            translucent: translucent.dataUrl,
+            opaque: opaque.dataUrl
+          }
         }
       });
       break;


### PR DESCRIPTION
Removes some redundant calculations of the texture images in the texture panel each time models are switched or things are updated since textures are centralized (and the RGBA buffer is already readily available in the worker that ops are performed on).