### PR TITLE
streamline polygon calcs

### DIFF
--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -133,14 +133,3 @@ export const selectIsMeshOpaque = createSelector(
   selectObjectMeshIndex,
   (model, meshIndex) => model?.meshes[meshIndex]?.isOpaque
 );
-
-export const selectPixelDataUrls = createSelector(
-  selectTextureDefs,
-  async (textureDefs) => {
-    for await (const def of textureDefs) {
-      for await (const [type, url] of Object.entries(def.bufferUrls)) {
-        const pixels = new Uint8ClampedArray(await objectUrlToBuffer(url));
-      }
-    }
-  }
-);

--- a/src/types/NLAbstractions.d.ts
+++ b/src/types/NLAbstractions.d.ts
@@ -69,6 +69,7 @@ declare global {
     flags: PolyTypeFlags;
     vertices: NLVertex[];
     vertexCount: number;
+    indices: number[];
     actualVertexCount: number;
     vertexGroupModeValue: number;
     vertexGroupMode: 'regular' | 'triple';


### PR DESCRIPTION
Closes #15 

Speeds up model's initial renders between 20-30% or ~40% on wireframe view. More importantly, makes some progress towards #76 since indices need to be immediately readable without recalculations in the texture panel to display UV data.