### PR TITLE
hotkey to download textures with translucency or opaque

### DIFF
--- a/src/components/dialogs/app-info/sections/Contributors.tsx
+++ b/src/components/dialogs/app-info/sections/Contributors.tsx
@@ -34,11 +34,9 @@ export default function Contributors() {
           VincentNL, egregiousguy, zocker-160, bankbank, TVIndustries,
           mountainmanjed
         </Typography>
-        <Typography variant={'subtitle1'}>
-          Early User Testing & Feedback
-        </Typography>
+        <Typography variant={'subtitle1'}>User Testing & Feedback</Typography>
         <Typography variant={'h6'}>
-          Magnetro2K, Paxtez, DJ Clayface, Toan
+          Magnetro2K, Paxtez, DJ Clayface, Toan, Blindfire604
         </Typography>
       </StyledContent>
     </div>

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -11,9 +11,11 @@ import {
   selectIsMeshOpaque,
   useAppDispatch
 } from '@/store';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { bufferToObjectUrl, objectUrlToBuffer } from '@/utils/data';
 import loadRGBABuffersFromFile from '@/utils/images/loadRGBABufferFromFile';
+import { useKeyPress } from '@react-typed-hooks/use-key-press';
+import { SourceTextureData } from '@/utils/textures/SourceTextureData';
 
 const StyledPanelTexture = styled('div')(
   ({ theme }) =>
@@ -201,11 +203,7 @@ export default function GuiPanelTexture({
           textureIndex={textureIndex}
           width={textureDef.width}
           height={textureDef.height}
-          pixelsObjectUrl={
-            textureDef.bufferUrls.opaque ||
-            textureDef.bufferUrls.translucent ||
-            ''
-          }
+          pixelsObjectUrls={textureDef.bufferUrls as SourceTextureData}
           onReplaceImageFile={onSelectNewImageFile}
         />
       </div>

--- a/src/components/panel/textures/GuiPanelTextureMenu.tsx
+++ b/src/components/panel/textures/GuiPanelTextureMenu.tsx
@@ -127,12 +127,12 @@ export default function GuiPanelTextureMenu({
         label: (
           <>
             <Icon path={mdiFileDownload} size={1} />
-            Download{dlAsTranslucent ? ' (T)' : ''}
+            Download{dlAsTranslucent ? ' (T)' : ' (O)'}
           </>
         ),
-        tooltip: `Download texture as a PNG${
-          dlAsTranslucent ? ' with translucency' : ''
-        }.`,
+        tooltip: `Download texture as a PNG [${
+          dlAsTranslucent ? 'translucent' : 'opaque'
+        }]. Press 'T' key to toggle translucency.`,
         onClick: async () => {
           const bufferUrl =
             (!dlAsTranslucent
@@ -164,7 +164,8 @@ export default function GuiPanelTextureMenu({
           </>
         ),
         tooltip:
-          'Replace this texture with another image file that is the same size',
+          'Replace this texture with another image file that has the same width and height. ' +
+          'Special zero-alpha pixels will be auto re-applied.',
         onClick() {
           openFileSelector();
           handleClose();


### PR DESCRIPTION
Added the ability to toggle translucency as a way to address some feedback from Blindfire in the scenario such as editing chains on STG00 (in video below). Also clarified menus a bit.

https://github.com/rob2d/modnao/assets/1799905/0f0df866-2754-49b9-9aa4-180212577b31

