### PR TITLE
update file select name checks, fix cvs2 texture viewing

### DIFF
--- a/src/hooks/useSupportedFilePicker.ts
+++ b/src/hooks/useSupportedFilePicker.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useFilePicker } from 'use-file-picker';
 import {
+  loadDedicatedTextureFile,
   loadPolygonFile,
   loadTextureFile,
   useAppDispatch,
@@ -48,13 +49,13 @@ export default function useSupportedFilePicker(
 
     let selectedPolygonFile: File | undefined = undefined;
     let selectedTextureFile: File | undefined = undefined;
-    let dedicatedTextureFile: File | undefined = undefined;
+    let selectedDedicatedTextureFile: File | undefined = undefined;
 
     const DEDICATED_TEXTURE_FILE_ERROR =
       'Cannot select other files with dedicated texture files at this time';
 
     plainFiles.forEach((f, i) => {
-      if (dedicatedTextureFile) {
+      if (selectedDedicatedTextureFile) {
         handleError(DEDICATED_TEXTURE_FILE_ERROR);
         return;
       }
@@ -65,7 +66,7 @@ export default function useSupportedFilePicker(
           return;
         }
 
-        dedicatedTextureFile = f;
+        selectedDedicatedTextureFile = f;
         return;
       }
 
@@ -88,7 +89,11 @@ export default function useSupportedFilePicker(
       }
     });
 
-    if (!selectedPolygonFile && !selectedTextureFile && !dedicatedTextureFile) {
+    if (
+      !selectedPolygonFile &&
+      !selectedTextureFile &&
+      !selectedDedicatedTextureFile
+    ) {
       onError(
         'Invalid stage file selected; Please select a file in the form STG**POL.BIN along with STG**TEX.BIN, or PL**_FAC.BIN or PL**_WIN.BIN'
       );
@@ -109,6 +114,10 @@ export default function useSupportedFilePicker(
           );
           return;
         }
+      }
+
+      if (selectedDedicatedTextureFile) {
+        dispatch(loadDedicatedTextureFile(selectedDedicatedTextureFile));
       }
     })();
   }, [plainFiles]);

--- a/src/hooks/useSupportedFilePicker.ts
+++ b/src/hooks/useSupportedFilePicker.ts
@@ -7,6 +7,15 @@ import {
   useAppSelector
 } from '@/store';
 
+/** includes character-specific super portraits and win poses */
+const DEDICATED_TEXTURE_FILE_REGEX = /^PL[0-9A-Z]{2}_(FAC|WIN).BIN$/i;
+
+/** polygon files which may be associated to textures */
+const POLYGON_FILE_REGEX = /^(STG|DM)[0-9A-Z]{2}POL\.BIN$/i;
+
+/** textures which must be associated with polygons */
+const TEXTURE_FILE_REGEX = /^(STG|DM)[0-9A-Z]{2}TEX(.modnao)?\.BIN$/i;
+
 /**
  * handle a user selection of a file client-side
  * in order to dispatch action to stream that data
@@ -29,36 +38,59 @@ export default function useSupportedFilePicker(
   });
 
   useEffect(() => {
+    const handleError = (error: string) => {
+      onError(error);
+      throw new Error(error);
+    };
     if (!plainFiles[0]) {
       return;
     }
 
     let selectedPolygonFile: File | undefined = undefined;
     let selectedTextureFile: File | undefined = undefined;
+    let dedicatedTextureFile: File | undefined = undefined;
 
-    plainFiles.forEach((f) => {
-      if (f.name.match(/^(STG|DM)[0-9A-Z]{2}POL\.BIN$/)) {
+    const DEDICATED_TEXTURE_FILE_ERROR =
+      'Cannot select other files with dedicated texture files at this time';
+
+    plainFiles.forEach((f, i) => {
+      if (dedicatedTextureFile) {
+        handleError(DEDICATED_TEXTURE_FILE_ERROR);
+        return;
+      }
+
+      if (f.name.match(DEDICATED_TEXTURE_FILE_REGEX)) {
+        if (i > 0) {
+          handleError(DEDICATED_TEXTURE_FILE_ERROR);
+          return;
+        }
+
+        dedicatedTextureFile = f;
+        return;
+      }
+
+      if (f.name.match(POLYGON_FILE_REGEX)) {
         if (!selectedPolygonFile) {
           selectedPolygonFile = f;
         } else {
-          onError('Cannot select more than one polygon file at this time');
+          onError('Cannot select more than one polygon file at a time');
           return;
         }
       }
 
-      if (f.name.match(/^(STG|DM)[0-9A-Z]{2}TEX(.modnao)?\.BIN$/)) {
+      if (f.name.match(TEXTURE_FILE_REGEX)) {
         if (!selectedTextureFile) {
           selectedTextureFile = f;
         } else {
-          onError('Cannot select more than one texture file at this time');
+          onError('Cannot select more than one texture file');
           return;
         }
       }
     });
 
-    if (!selectedPolygonFile && !selectedTextureFile) {
+    if (!selectedPolygonFile && !selectedTextureFile && !dedicatedTextureFile) {
       onError(
-        'Invalid stage file selected; Please select a file in the form STG**TEX.BIN or STG**POL.BIN'
+        'Invalid stage file selected; Please select a file in the form STG**POL.BIN along with STG**TEX.BIN, or PL**_FAC.BIN or PL**_WIN.BIN'
       );
       return;
     }

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -110,13 +110,15 @@ export const loadDedicatedTextureFile = createAsyncThunk<
 >(
   `${sliceName}/loadDedicatedTextureFile`,
   async (file, { getState, dispatch }) => {
-    const arrayBuffer = await file.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-
+    window.alert('These dedicated texture files are not yet supported');
+    /*
     const pointer1 = buffer.readUInt32LE(0);
     const pointer2 = buffer.readUInt32LE(4);
     const pointer3 = buffer.readUInt32LE(8);
 
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    // revoke URL for existing texture buffer url in state
     dispatch({
       type: loadPolygonFile.fulfilled.type,
       payload: {
@@ -141,6 +143,7 @@ export const loadDedicatedTextureFile = createAsyncThunk<
     });
 
     await dispatch(loadTextureFile(file));
+    */
   }
 );
 
@@ -390,7 +393,6 @@ const modelDataSlice = createSlice({
     builder.addCase(
       loadDedicatedTextureFile.pending,
       (state: ModelDataState) => {
-        // TODO: in thunk, revoke URL for existing buffer Urls
         state.polygonBufferUrl = undefined;
         state.textureBufferUrl = undefined;
         state.textureDefs = [];

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -103,6 +103,40 @@ export const initialModelDataState: ModelDataState = {
   hasCompressedTextures: false
 };
 
+export const loadDedicatedTextureFile = createAsyncThunk<
+  void,
+  File,
+  { state: AppState }
+>(
+  `${sliceName}/loadDedicatedTextureFile`,
+  async (file, { getState, dispatch }) => {
+    dispatch({
+      type: loadPolygonFile.fulfilled.type,
+      payload: {
+        models: [],
+        fileName: undefined,
+        polygonBufferUrl: undefined,
+        textureDefs: [
+          {
+            width: 256,
+            height: 256,
+            colorFormat: 'ARGB4444',
+            colorFormatValue: 2,
+            bufferUrls: {},
+            dataUrls: {},
+            type: 0,
+            address: 0,
+            baseLocation: 0,
+            ramOffset: 0
+          }
+        ]
+      }
+    });
+
+    await dispatch(loadTextureFile(file));
+  }
+);
+
 export const loadPolygonFile = createAsyncThunk<
   LoadPolygonsPayload,
   File,
@@ -343,6 +377,16 @@ const modelDataSlice = createSlice({
         state.textureFileName = fileName;
         state.hasCompressedTextures = hasCompressedTextures;
         state.textureBufferUrl = textureBufferUrl;
+      }
+    );
+
+    builder.addCase(
+      loadDedicatedTextureFile.pending,
+      (state: ModelDataState) => {
+        // TODO: in thunk, revoke URL for existing buffer Urls
+        state.polygonBufferUrl = undefined;
+        state.textureBufferUrl = undefined;
+        state.textureDefs = [];
       }
     );
 

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -110,6 +110,13 @@ export const loadDedicatedTextureFile = createAsyncThunk<
 >(
   `${sliceName}/loadDedicatedTextureFile`,
   async (file, { getState, dispatch }) => {
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    const pointer1 = buffer.readUInt32LE(0);
+    const pointer2 = buffer.readUInt32LE(4);
+    const pointer3 = buffer.readUInt32LE(8);
+
     dispatch({
       type: loadPolygonFile.fulfilled.type,
       payload: {
@@ -118,15 +125,15 @@ export const loadDedicatedTextureFile = createAsyncThunk<
         polygonBufferUrl: undefined,
         textureDefs: [
           {
-            width: 256,
-            height: 256,
-            colorFormat: 'ARGB4444',
+            width: 128,
+            height: 128,
+            colorFormat: 'RGB565',
             colorFormatValue: 2,
             bufferUrls: {},
             dataUrls: {},
             type: 0,
             address: 0,
-            baseLocation: 0,
+            baseLocation: pointer3,
             ramOffset: 0
           }
         ]

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -46,12 +46,9 @@ async function loadTextureBuffer(
           const offsetDrawn = encodeZMortonPosition(offset - yOffset, y);
           const readOffset =
             t.baseLocation - t.ramOffset + offsetDrawn * COLOR_SIZE;
-          // textures may point out of bounds (this would be
-          // to RAM elswhere in-game)
-          if (readOffset >= buffer.length) {
-            if (!failOutOfBounds) {
-              break;
-            }
+          // textures may point out of bounds (this would be to RAM elswhere in-game)
+          if (readOffset >= buffer.length && !failOutOfBounds) {
+            break;
           }
 
           const colorValue = buffer.readUInt16LE(readOffset);
@@ -110,12 +107,14 @@ export default async function loadTextureFile({
   buffer: Buffer;
 }) {
   let result: Result;
+  const expectOOBReferences = fileName.toLowerCase().match('^dm');
+  const decompressContent = fileName.toLowerCase().match(/^pl{0-9}[2]_fac/);
 
   try {
     const textureBufferData = await loadTextureBuffer(
       buffer,
       textureDefs,
-      true
+      !expectOOBReferences
     );
     const textureBufferUrl = await bufferToObjectUrl(buffer);
 

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -108,7 +108,6 @@ export default async function loadTextureFile({
 }) {
   let result: Result;
   const expectOOBReferences = fileName.toLowerCase().match('^dm');
-  const decompressContent = fileName.toLowerCase().match(/^pl{0-9}[2]_fac/);
 
   try {
     const textureBufferData = await loadTextureBuffer(


### PR DESCRIPTION
Adds fixes for file checking so that loading logic does not continue with partial or textures with no polys. 

Also begins to chip away towards #87 with file name checks and fixes an issue loading CVS2 stages and DM files for viewing. Previously in order to add support for DM files, this supported was removed as those files could not be edited but revisiting/testing all cases to expand support to PL_NN_FAC files.