### PR TITLE
texture RLE compression file-logic iteration

### DIFF
--- a/src/utils/textures/parse/decompressTextureBuffer.ts
+++ b/src/utils/textures/parse/decompressTextureBuffer.ts
@@ -11,45 +11,43 @@ export default function decompressTextureBuffer(bufferPassed: Buffer) {
   let bitmask = 0b0;
   let wordsBackCount = 0;
   let grabWordCount = 0;
-  let extraWordCount = 0;
   let chunk = 0;
 
   for (let i = 0; i < buffer.length / WORD_SIZE; i++) {
-    let value = buffer.readUInt16LE(i * WORD_SIZE);
+    let word = buffer.readUInt16LE(i * WORD_SIZE);
 
     if (applyBitMask) {
-      bitmask = value;
+      bitmask = word;
       applyBitMask = false;
       continue;
     }
 
-    // reset this to be diffed on each loop
-    extraWordCount = 0;
     const isCompressed = bitmask & (COMPRESSION_FLAG >> chunk);
+    let extraWordCount = 0;
 
     if (!isCompressed) {
-      output.push(value);
-    } else if (value === 0) {
+      output.push(word);
+    } else if (word === 0) {
       break;
     } else {
       // check that only the lower 11-bits are used;
       // this says it is a 4 byte value, where the number
       // of words back to go is value & 0x7ff
-      const is32Bit = (value & 0b0111_1111_1111) === value;
+      const is32Bit = (word & 0b0111_1111_1111) === word;
 
       if (!is32Bit) {
         // the number of words to grab are in the 5 MSb
-        grabWordCount = (value >> 11) & 0b1111_1;
+        grabWordCount = (word >> 11) & 0b1111_1;
         // the number of words to go back are in the 11 LSb */
-        wordsBackCount = value & 0b0111_1111_1111;
+        wordsBackCount = word & 0b0111_1111_1111;
       } else {
-        wordsBackCount = value;
+        wordsBackCount = word;
 
         // advance/read an extra 2 bytes
         grabWordCount = buffer.readUInt16LE(++i * WORD_SIZE);
 
         // value now becomes 32-bit
-        value = (value << 16) | grabWordCount;
+        word = (word << 16) | grabWordCount;
       }
 
       if (wordsBackCount < grabWordCount) {
@@ -57,14 +55,13 @@ export default function decompressTextureBuffer(bufferPassed: Buffer) {
         grabWordCount = wordsBackCount;
       }
 
-      const nextWordPattern = [];
-
-      for (let j = 0; j < grabWordCount; j++) {
-        nextWordPattern.push(output[output.length - wordsBackCount + j]);
-      }
+      const appendedSequence = output.slice(
+        output.length - wordsBackCount,
+        output.length - wordsBackCount + grabWordCount
+      );
 
       for (let j = 0; j < grabWordCount + extraWordCount; j++) {
-        output.push(nextWordPattern[j % nextWordPattern.length]);
+        output.push(appendedSequence[j % appendedSequence.length]);
       }
     }
     chunk += 1;

--- a/src/utils/textures/parse/decompressTextureBuffer.ts
+++ b/src/utils/textures/parse/decompressTextureBuffer.ts
@@ -38,7 +38,7 @@ export default function decompressTextureBuffer(bufferPassed: Buffer) {
       if (!is32Bit) {
         // the number of words to grab are in the 5 MSb
         grabWordCount = (word >> 11) & 0b1111_1;
-        // the number of words to go back are in the 11 LSb */
+        // the number of words to go back are in the 11 LSb
         wordsBackCount = word & 0b0111_1111_1111;
       } else {
         wordsBackCount = word;
@@ -64,6 +64,7 @@ export default function decompressTextureBuffer(bufferPassed: Buffer) {
         output.push(appendedSequence[j % appendedSequence.length]);
       }
     }
+
     chunk += 1;
 
     // chunk loops every 2 bytes

--- a/src/utils/textures/parse/decompressTextureBuffer.ts
+++ b/src/utils/textures/parse/decompressTextureBuffer.ts
@@ -6,7 +6,7 @@ const COMPRESSION_FLAG = 0b1000_0000_0000_0000;
 export default function decompressTextureBuffer(bufferPassed: Buffer) {
   const buffer = Buffer.from(bufferPassed);
   const output: number[] = [];
-  let applyBitMask = true;
+  let applyBitmask = true;
 
   let bitmask = 0b0;
   let wordsBackCount = 0;
@@ -16,9 +16,9 @@ export default function decompressTextureBuffer(bufferPassed: Buffer) {
   for (let i = 0; i < buffer.length / WORD_SIZE; i++) {
     let word = buffer.readUInt16LE(i * WORD_SIZE);
 
-    if (applyBitMask) {
+    if (applyBitmask) {
       bitmask = word;
-      applyBitMask = false;
+      applyBitmask = false;
       continue;
     }
 
@@ -70,7 +70,7 @@ export default function decompressTextureBuffer(bufferPassed: Buffer) {
     // chunk loops every 2 bytes
     if (chunk == 0x10) {
       chunk = 0;
-      applyBitMask = true;
+      applyBitmask = true;
     }
   }
 


### PR DESCRIPTION
Iterative to get compressed file export technically supported (not enabled in UI yet); partially addresses #96.

Being able to export RLE format is big step towards actually editing more resources in different games/files. Unfortunately, on some resources it goes out of bounds in RAM of game but technically is encoded correctly so it will load and replace RAM sections until the end of an image now.

Edited texture to export:
![image](https://github.com/rob2d/modnao/assets/1799905/a5c7c151-5f39-45be-a157-4a7bf4186728)

Loaded pixels in VRAM (detwiddled, decompressed, but artifacts occur due to image boundary leaks into other RAM):
![image](https://github.com/rob2d/modnao/assets/1799905/c5a70417-0eec-4f2c-a513-e96eaf4e0fff)

On next iteration, will track sequences to re-use repeating data further back than the immediately repeating words. Then a further iteration can add support to variable sequences, but want to see the actual file compression metrics to determine whether it's worth a more complex algorithm than tracking singular 16-bit words repeating at different places.