### PR TITLE
replacement dialog options: preserve zero-alpha on output, and options to view translucent or not

### DIFF
--- a/src/components/dialogs/replace-texture/ReplaceTexture.tsx
+++ b/src/components/dialogs/replace-texture/ReplaceTexture.tsx
@@ -386,7 +386,7 @@ export default function ReplaceTexture() {
       );
       setOriginTextureBuffer(textureBuffer);
     })();
-  }, []);
+  }, [textureDefs?.[textureIndex]?.bufferUrls?.['translucent'] || '']);
 
   const originTextureDataUrl =
     textureDefs?.[textureIndex]?.dataUrls?.[

--- a/src/components/dialogs/replace-texture/ReplaceTexture.tsx
+++ b/src/components/dialogs/replace-texture/ReplaceTexture.tsx
@@ -364,7 +364,6 @@ export default function ReplaceTexture() {
               rgbaBuffer[i + 3] = 0;
             }
           }
-
           setProcessedRgba(rgbaBuffer);
         } else {
           setProcessedRgba(resizedImage.getRGBAData());
@@ -417,7 +416,7 @@ export default function ReplaceTexture() {
             <div className='controls'>
               <FormControlLabel
                 label={<Icon path={mdiMagnify} size={1} />}
-                labelPlacement='end'
+                labelPlacement='start'
                 control={
                   <Slider
                     size='small'
@@ -443,7 +442,7 @@ export default function ReplaceTexture() {
               </Tooltip>
               <FormControlLabel
                 label={<Icon path={mdiCropRotate} size={1} />}
-                labelPlacement='end'
+                labelPlacement='start'
                 control={
                   <Slider
                     size='small'

--- a/src/components/dialogs/replace-texture/ReplaceTexture.tsx
+++ b/src/components/dialogs/replace-texture/ReplaceTexture.tsx
@@ -14,6 +14,7 @@ import Icon from '@mdi/react';
 import { nanoid } from 'nanoid';
 import {
   Button,
+  Checkbox,
   Divider,
   FormControlLabel,
   Slider,
@@ -41,7 +42,7 @@ const Styled = styled('div')(
 & {
   display: flex;
   flex-direction: column;
-  height: 80vh;
+  height: calc(100vh - 64px);
   width: 100%;
 }
 
@@ -114,6 +115,11 @@ const Styled = styled('div')(
 & .controls .MuiFormControlLabel-label {
   display: flex;
   align-items: center;
+}
+
+& .controls .MuiFormControlLabel-root.MuiFormControlLabel-labelPlacementStart,
+& .result .MuiFormControlLabel-root.MuiFormControlLabel-labelPlacementStart {
+  margin-left: 0;
 }
 
 & .controls > .MuiButton-root {
@@ -239,6 +245,15 @@ export default function ReplaceTexture() {
     }),
     [originalWidth, originalHeight]
   );
+
+  const [viewTranslucentOrigin, setViewTranslucentOrigin] = useState(
+    () => false
+  );
+
+  const [viewTranslucentPreview, setViewTranslucentPreview] = useState(
+    () => false
+  );
+
   useEffect(() => {
     (() =>
       (async () => {
@@ -300,7 +315,9 @@ export default function ReplaceTexture() {
   );
 
   const originTextureDataUrl =
-    textureDefs?.[textureIndex]?.dataUrls?.opaque || '';
+    textureDefs?.[textureIndex]?.dataUrls?.[
+      viewTranslucentOrigin ? 'translucent' : 'opaque'
+    ] || '';
 
   return (
     <>
@@ -416,6 +433,19 @@ export default function ReplaceTexture() {
                   <b>{textureFormat}</b>
                 </Typography>
               </div>
+              <Tooltip
+                title='Renders fully transparent pixels as transparent; this is useful in cases where there are transparent pixels that have color data.'
+                placement='top-start'
+              >
+                <FormControlLabel
+                  control={<Checkbox checked={viewTranslucentOrigin} />}
+                  label='View Translucent'
+                  labelPlacement='start'
+                  onChange={() =>
+                    setViewTranslucentOrigin(!viewTranslucentOrigin)
+                  }
+                />
+              </Tooltip>
             </div>
             <Divider flexItem />
             <div className='result'>
@@ -429,6 +459,19 @@ export default function ReplaceTexture() {
                   style={referenceTextureStyle}
                 />
               </div>
+              <Tooltip
+                title='Renders fully transparent pixels as transparent; this is useful in cases where there are transparent pixels that have color data.'
+                placement='top-start'
+              >
+                <FormControlLabel
+                  control={<Checkbox checked={viewTranslucentPreview} />}
+                  label='View Translucent'
+                  labelPlacement='start'
+                  onChange={() =>
+                    setViewTranslucentPreview(!viewTranslucentPreview)
+                  }
+                />
+              </Tooltip>
             </div>
             <div className='dialog-actions'>
               <Button

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -79,6 +79,7 @@ const StyledPanelTexture = styled('div')(
     width: ${IMG_SIZE};
     height: ${IMG_SIZE};
     border: 3px solid transparent;
+    pointer-events: none;
   }
 
   .uv-overlay img {


### PR DESCRIPTION
With this change: instead of an implied default, the user now has full control on how formatted texture transparencies are applied (and can get a full preview on special zero-alpha cases)

Related to editing PL_WIN/FAC files for initial compression supported (#96) since there's no point to edit portraits with fixed transparency segments when exporting.

https://github.com/rob2d/modnao/assets/1799905/358e4206-5e49-473b-b918-7e4cee9b7596

