### PR TITLE
optimize RLE compression

### DIFF
--- a/src/utils/ds/Queue.ts
+++ b/src/utils/ds/Queue.ts
@@ -1,0 +1,69 @@
+class QueueNode<T> {
+  constructor(
+    public data: T,
+    public next: QueueNode<T> | null = null,
+    public prev: QueueNode<T> | null = null
+  ) {}
+}
+
+export default class Queue<T> {
+  front: QueueNode<T> | null = null;
+  rear: QueueNode<T> | null = null;
+  size = 0;
+
+  enqueue(item: T): void {
+    const newNode = new QueueNode(item);
+    if (this.size === 0) {
+      this.front = newNode;
+      this.rear = newNode;
+    } else {
+      newNode.prev = this.rear;
+      this.rear!.next = newNode;
+      this.rear = newNode;
+    }
+    this.size++;
+  }
+
+  dequeue(): T | undefined {
+    if (this.size === 0) {
+      return undefined;
+    }
+    const removedNode = this.front;
+    this.front = removedNode!.next;
+    if (this.front) {
+      this.front.prev = null;
+    } else {
+      this.rear = null; // If the queue is now empty
+    }
+    this.size--;
+    return removedNode!.data;
+  }
+
+  peek(): T | undefined {
+    return this.front?.data;
+  }
+
+  isEmpty(): boolean {
+    return this.size === 0;
+  }
+
+  clear(): void {
+    this.front = null;
+    this.rear = null;
+    this.size = 0;
+  }
+}
+
+// Example usage:
+const queue = new Queue<number>();
+
+queue.enqueue(1);
+queue.enqueue(2);
+queue.enqueue(3);
+
+console.log(queue.dequeue()); // Output: 1
+console.log(queue.peek()); // Output: 2
+console.log(queue.size); // Output: 2
+
+queue.clear();
+console.log(queue.isEmpty()); // Output: true


### PR DESCRIPTION
Runs between 30-50% faster in local benchmarks on `PL_WIN` and `SELSTG.BIN` files

- run conditionals in order of likelihood to fail
- use double link list queues and one main loop vs re-iterating
- `Buffer.alloc` vs `Buffer.from(...)` for output buffer