### PR TITLE
PL_FAC export progress: texture type state + LZSS compression edge case fixes

### DIFF
--- a/src/components/panel/GuiPanel.tsx
+++ b/src/components/panel/GuiPanel.tsx
@@ -126,7 +126,7 @@ const StyledPaper = styled(Paper)(
       margin-top: ${theme.spacing(1)};
     }
 
-    & .MuiDivider-root:not(:first-child) {
+    & .MuiDivider-root:not(:first-child):not(.export-texture-button-container + .MuiDivider-root) {
       padding-top: ${theme.spacing(1)};
     }
 

--- a/src/components/panel/GuiPanelTextures.tsx
+++ b/src/components/panel/GuiPanelTextures.tsx
@@ -115,7 +115,7 @@ export default function GuiPanelViewOptions() {
     <GuiPanelSection title='Textures' subtitle={textureFileName}>
       <Styled className='textures'>
         {textures}
-        {false ? undefined : (
+        {!offsceneTextures.length ? undefined : (
           <>
             {!models.length ? undefined : (
               <Divider flexItem>
@@ -126,7 +126,7 @@ export default function GuiPanelViewOptions() {
           </>
         )}
       </Styled>
-      {false ? undefined : (
+      {!canExportTextures ? undefined : (
         <div className='export-texture-button-container'>
           <GuiPanelButton
             tooltip='Download texture ROM binary with replaced images'

--- a/src/components/panel/GuiPanelTextures.tsx
+++ b/src/components/panel/GuiPanelTextures.tsx
@@ -115,7 +115,7 @@ export default function GuiPanelViewOptions() {
     <GuiPanelSection title='Textures' subtitle={textureFileName}>
       <Styled className='textures'>
         {textures}
-        {!offsceneTextures.length ? undefined : (
+        {false ? undefined : (
           <>
             {!models.length ? undefined : (
               <Divider flexItem>
@@ -126,7 +126,7 @@ export default function GuiPanelViewOptions() {
           </>
         )}
       </Styled>
-      {canExportTextures ? undefined : (
+      {false ? undefined : (
         <div className='export-texture-button-container'>
           <GuiPanelButton
             tooltip='Download texture ROM binary with replaced images'

--- a/src/hooks/useSupportedFilePicker.ts
+++ b/src/hooks/useSupportedFilePicker.ts
@@ -10,38 +10,12 @@ import {
   useAppDispatch,
   useAppSelector
 } from '@/store';
-
-export type TEXTURE_FILE_TYPE =
-  | 'mvc2-stage-preview'
-  | 'character-portraits'
-  | 'mvc2-character-win'
-  | 'polygon-mapped'
-  | 'mvc2-end-file';
-
-/** includes character-specific super portraits and end-game images */
-export const CHARACTER_PORTRAITS_REGEX_FILE = /^PL[0-9A-Z]{2}_FAC.BIN$/i;
-
-/** includes character-specific super portraits and end-game images */
-export const MVC2_CHARACTER_WIN_REGEX_FILE = /^PL[0-9A-Z]{2}_WIN.BIN$/i;
+import textureFileTypeMap, {
+  TextureFileType
+} from '@/utils/textures/files/textureFileTypeMap';
 
 /** polygon files which may be associated to textures */
 export const POLYGON_FILE_REGEX = /^(((STG|DM|DC)[0-9A-Z]{2})|EFKY)POL\.BIN$/i;
-
-/** textures which must be associated with polygons */
-export const TEXTURE_FILE_REGEX =
-  /^(((STG|DM|DC)[0-9A-Z]{2})|EFKY)TEX(.modnao)?\.BIN$/i;
-
-/** textures associated with stage selection previews */
-export const MVC2_STAGE_PREVIEWS_FILE_REGEX = /^SELSTG\.BIN$/i;
-
-export const MVC2_END_FILE_REGEX = /^END(DC|NM)TEX\.BIN$/i;
-
-const typeRegexMappings: [TEXTURE_FILE_TYPE, RegExp][] = [
-  ['character-portraits', CHARACTER_PORTRAITS_REGEX_FILE],
-  ['mvc2-character-win', MVC2_CHARACTER_WIN_REGEX_FILE],
-  ['mvc2-stage-preview', MVC2_STAGE_PREVIEWS_FILE_REGEX],
-  ['mvc2-end-file', MVC2_END_FILE_REGEX]
-];
 
 /**
  * handle a user selection of a file client-side
@@ -73,7 +47,7 @@ export default function useSupportedFilePicker(
       return;
     }
 
-    let textureType: TEXTURE_FILE_TYPE | undefined;
+    let textureType: TextureFileType | undefined;
 
     let selectedPolygonFile: File | undefined = undefined;
     let selectedTextureFile: File | undefined = undefined;
@@ -87,7 +61,7 @@ export default function useSupportedFilePicker(
         return;
       }
 
-      for (const [type, regex] of typeRegexMappings) {
+      for (const [type, regex] of Object.entries(textureFileTypeMap)) {
         if (f.name.match(regex)) {
           if (i > 0) {
             handleError(DEDICATED_TEXTURE_FILE_ERROR);
@@ -95,7 +69,7 @@ export default function useSupportedFilePicker(
           }
 
           selectedTextureFile = f;
-          textureType = type;
+          textureType = type as TextureFileType;
           return;
         }
       }
@@ -109,7 +83,7 @@ export default function useSupportedFilePicker(
         }
       }
 
-      if (f.name.match(TEXTURE_FILE_REGEX)) {
+      if (f.name.match(textureFileTypeMap['polygon-mapped'])) {
         if (!selectedTextureFile) {
           selectedTextureFile = f;
           textureType = 'polygon-mapped';
@@ -150,7 +124,7 @@ export default function useSupportedFilePicker(
       }
 
       switch (textureType) {
-        case 'character-portraits': {
+        case 'mvc2-character-portraits': {
           dispatch(loadCharacterPortraitsFile(selectedTextureFile));
           break;
         }

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -15,6 +15,7 @@ import { selectSceneTextureDefs } from './selectors';
 import { SourceTextureData } from '@/utils/textures/SourceTextureData';
 import WorkerThreadPool from '../utils/WorkerThreadPool';
 import { decompressTextureBuffer } from '@/utils/textures/parse';
+import { batch } from 'react-redux';
 
 const workerPool = new WorkerThreadPool();
 
@@ -176,17 +177,6 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
     ramOffset: 0
   }));
 
-  // revoke URL for existing texture buffer url in state
-  dispatch({
-    type: loadPolygonFile.fulfilled.type,
-    payload: {
-      models: [],
-      fileName: undefined,
-      polygonBufferUrl: undefined,
-      textureDefs
-    }
-  });
-
   const thread = workerPool.allocate();
 
   const result = await new Promise<LoadTexturesPayload>((resolve) => {
@@ -196,7 +186,19 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
           ...event.data.result,
           hasCompressedTextures: true
         };
-        dispatch({ type: loadTextureFile.fulfilled.type, payload });
+        batch(() => {
+          // revoke URL for existing texture buffer url in state
+          dispatch({
+            type: loadPolygonFile.fulfilled.type,
+            payload: {
+              models: [],
+              fileName: undefined,
+              polygonBufferUrl: undefined,
+              textureDefs
+            }
+          });
+          dispatch({ type: loadTextureFile.fulfilled.type, payload });
+        });
         resolve(payload);
 
         workerPool.unallocate(thread);
@@ -282,21 +284,22 @@ export const loadMvc2CharacterWinFile = createAsyncThunk<
     }
   ];
 
-  dispatch({
-    type: loadPolygonFile.fulfilled.type,
-    payload: {
-      models: [],
-      fileName: undefined,
-      polygonBufferUrl: undefined,
-      textureDefs
-    }
-  });
-
   const result = (await loadCompressedTextureFiles(
     file,
     textureDefs,
     (payload: LoadTexturesPayload) =>
-      dispatch({ type: loadTextureFile.fulfilled.type, payload })
+      batch(() => {
+        dispatch({
+          type: loadPolygonFile.fulfilled.type,
+          payload: {
+            models: [],
+            fileName: undefined,
+            polygonBufferUrl: undefined,
+            textureDefs
+          }
+        });
+        dispatch({ type: loadTextureFile.fulfilled.type, payload });
+      })
   )) as LoadTexturesPayload;
 
   return result;
@@ -349,21 +352,23 @@ export const loadMvc2StagePreviewsFile = createAsyncThunk<
     ramOffset: 0
   });
 
-  dispatch({
-    type: loadPolygonFile.fulfilled.type,
-    payload: {
-      models: [],
-      fileName: undefined,
-      polygonBufferUrl: undefined,
-      textureDefs
-    }
-  });
-
   const result = (await loadCompressedTextureFiles(
     file,
     textureDefs,
     (payload: LoadTexturesPayload) =>
-      dispatch({ type: loadTextureFile.fulfilled.type, payload })
+      // TODO: DRY into action
+      batch(() => {
+        dispatch({
+          type: loadPolygonFile.fulfilled.type,
+          payload: {
+            models: [],
+            fileName: undefined,
+            polygonBufferUrl: undefined,
+            textureDefs
+          }
+        });
+        dispatch({ type: loadTextureFile.fulfilled.type, payload });
+      })
   )) as LoadTexturesPayload;
 
   return result;
@@ -435,21 +440,22 @@ export const loadMvc2EndFile = createAsyncThunk<
     ramOffset: 0
   });
 
-  dispatch({
-    type: loadPolygonFile.fulfilled.type,
-    payload: {
-      models: [],
-      fileName: undefined,
-      polygonBufferUrl: undefined,
-      textureDefs
-    }
-  });
-
   const result = (await loadCompressedTextureFiles(
     file,
     textureDefs,
     (payload: LoadTexturesPayload) =>
-      dispatch({ type: loadTextureFile.fulfilled.type, payload })
+      batch(() => {
+        dispatch({
+          type: loadPolygonFile.fulfilled.type,
+          payload: {
+            models: [],
+            fileName: undefined,
+            polygonBufferUrl: undefined,
+            textureDefs
+          }
+        });
+        dispatch({ type: loadTextureFile.fulfilled.type, payload });
+      })
   )) as LoadTexturesPayload;
 
   return result;

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -156,13 +156,6 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
     uint8Array.slice(pointers[1])
   ]);
 
-  console.log('buffer.length ->', buffer.length);
-  console.log('decompressedBuffer ->', decompressedBuffer.length);
-  console.log(
-    'decompressed - buffer ->',
-    decompressedBuffer.length - buffer.length
-  );
-
   const rleTextureSizes = [
     { width: 64, height: 64 },
     { width: 64, height: 64 },

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -156,6 +156,13 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
     uint8Array.slice(pointers[1])
   ]);
 
+  console.log('buffer.length ->', buffer.length);
+  console.log('decompressedBuffer ->', decompressedBuffer.length);
+  console.log(
+    'decompressed - buffer ->',
+    decompressedBuffer.length - buffer.length
+  );
+
   const rleTextureSizes = [
     { width: 64, height: 64 },
     { width: 64, height: 64 },

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -2,8 +2,7 @@ import {
   AnyAction,
   createAsyncThunk,
   createSlice,
-  PayloadAction,
-  ThunkDispatch
+  PayloadAction
 } from '@reduxjs/toolkit';
 import { HYDRATE } from 'next-redux-wrapper';
 import { NLTextureDef } from '@/types/NLAbstractions';
@@ -16,6 +15,7 @@ import { SourceTextureData } from '@/utils/textures/SourceTextureData';
 import WorkerThreadPool from '../utils/WorkerThreadPool';
 import { decompressTextureBuffer } from '@/utils/textures/parse';
 import { batch } from 'react-redux';
+import { TextureFileType } from '@/utils/textures/files/textureFileTypeMap';
 
 const workerPool = new WorkerThreadPool();
 
@@ -52,6 +52,7 @@ export type LoadTexturesPayload = {
   fileName: string;
   textureBufferUrl: string;
   hasCompressedTextures: boolean;
+  textureFileType: string;
 };
 
 export type LoadPolygonsPayload = {
@@ -87,6 +88,7 @@ export interface ModelDataState {
   };
   polygonFileName?: string;
   textureFileName?: string;
+  textureFileType?: TextureFileType;
   hasEditedTextures: boolean;
   hasCompressedTextures: boolean;
   textureBufferUrl?: string;
@@ -102,6 +104,7 @@ export const initialModelDataState: ModelDataState = {
   textureHistory: {},
   polygonFileName: undefined,
   textureFileName: undefined,
+  textureFileType: undefined,
   hasEditedTextures: false,
   hasCompressedTextures: false
 };

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { AppState } from './store';
-import { CHARACTER_PORTRAITS_REGEX_FILE } from '@/hooks/useSupportedFilePicker';
+import { CHARACTER_PORTRAITS_REGEX_FILE } from '@/utils/textures/files/textureFileTypeMap';
 
 export const selectModelIndex = (s: AppState) => s.modelViewer.modelIndex;
 

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -163,5 +163,5 @@ export const selectCanExportTextures = createSelector(
   selectTextureFileName,
   (textureFileName) =>
     Boolean(textureFileName) &&
-    textureFileName?.match(CHARACTER_PORTRAITS_REGEX_FILE)
+    !textureFileName?.match(CHARACTER_PORTRAITS_REGEX_FILE)
 );

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -71,6 +71,7 @@ export default async function exportTextureFile(
     case 'mvc2-character-portraits': {
       const buffer = Buffer.alloc(textureBuffer.length);
       textureBuffer.copy(buffer);
+
       const pointers = [
         textureBuffer.readUInt32LE(0),
         textureBuffer.readUInt32LE(4),
@@ -81,6 +82,7 @@ export default async function exportTextureFile(
         pointers[0],
         pointers[1]
       );
+
       const compressedRleTexture = compressTextureBuffer(
         Buffer.from(decompressedRleSection)
       );
@@ -95,8 +97,8 @@ export default async function exportTextureFile(
       const uint8Array = new Uint8Array(buffer);
       const outputBuffer = Buffer.concat([
         uint8Array.slice(0, 12),
-        uint8Array.slice(12 + decompressedRleSection.length)
         compressedRleTexture,
+        new Uint8Array(textureBuffer).slice(12 + decompressedRleSection.length)
       ]);
 
       output = new Blob([outputBuffer], {

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -69,7 +69,8 @@ export default async function exportTextureFile(
     // character portraits are an interesting niche case
     // where compression exists but not applied to the entire file
     case 'mvc2-character-portraits': {
-      const buffer = Buffer.from(new Uint8Array(textureBuffer));
+      const buffer = Buffer.alloc(textureBuffer.length);
+      textureBuffer.copy(buffer);
       const pointers = [
         textureBuffer.readUInt32LE(0),
         textureBuffer.readUInt32LE(4),
@@ -80,22 +81,22 @@ export default async function exportTextureFile(
         pointers[0],
         pointers[1]
       );
-      const compressedRleSection = compressTextureBuffer(
+      const compressedRleTexture = compressTextureBuffer(
         Buffer.from(decompressedRleSection)
       );
 
       buffer.writeUInt32LE(12, 0);
-      buffer.writeUInt32LE(12 + compressedRleSection.length, 4);
+      buffer.writeUInt32LE(12 + compressedRleTexture.length, 4);
       buffer.writeUInt32LE(
-        12 + compressedRleSection.length + (pointers[2] - pointers[1]),
+        12 + compressedRleTexture.length + (pointers[2] - pointers[1]),
         8
       );
 
       const uint8Array = new Uint8Array(buffer);
       const outputBuffer = Buffer.concat([
         uint8Array.slice(0, 12),
-        compressedRleSection,
         uint8Array.slice(12 + decompressedRleSection.length)
+        compressedRleTexture,
       ]);
 
       output = new Blob([outputBuffer], {

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -6,6 +6,7 @@ import rgbaToArgb4444 from '@/utils/color-conversions/rgbaToArgb4444';
 import { RgbaColor, TextureColorFormat } from '@/utils/textures';
 import { compressTextureBuffer } from '@/utils/textures/parse';
 import { objectUrlToBuffer } from '@/utils/data';
+import { TextureFileType } from './textureFileTypeMap';
 
 const COLOR_SIZE = 2;
 
@@ -22,7 +23,8 @@ export default async function exportTextureFile(
   textureDefs: NLTextureDef[],
   textureFileName = '',
   hasCompressedTextures: boolean,
-  textureBufferUrl: string
+  textureBufferUrl: string,
+  textureFileType: TextureFileType
 ): Promise<void> {
   const textureBuffer = Buffer.from(await objectUrlToBuffer(textureBufferUrl));
   if (!textureBuffer) {
@@ -61,13 +63,58 @@ export default async function exportTextureFile(
     }
   }
 
-  const outputBuffer = !hasCompressedTextures
-    ? textureBuffer
-    : compressTextureBuffer(textureBuffer);
+  let output: Blob;
 
-  const output = new Blob([outputBuffer], {
-    type: 'application/octet-stream'
-  });
+  switch (textureFileType) {
+    // character portraits are an interesting niche case
+    // where compression exists but not applied to the entire file
+    case 'mvc2-character-portraits': {
+      const buffer = Buffer.from(new Uint8Array(textureBuffer));
+      const pointers = [
+        textureBuffer.readUInt32LE(0),
+        textureBuffer.readUInt32LE(4),
+        textureBuffer.readUInt32LE(8)
+      ];
+
+      const decompressedRleSection = new Uint8Array(buffer).slice(
+        pointers[0],
+        pointers[1]
+      );
+      const compressedRleSection = compressTextureBuffer(
+        Buffer.from(decompressedRleSection)
+      );
+
+      buffer.writeUInt32LE(12, 0);
+      buffer.writeUInt32LE(12 + compressedRleSection.length, 4);
+      buffer.writeUInt32LE(
+        12 + compressedRleSection.length + (pointers[2] - pointers[1]),
+        8
+      );
+
+      const uint8Array = new Uint8Array(buffer);
+      const outputBuffer = Buffer.concat([
+        uint8Array.slice(0, 12),
+        compressedRleSection,
+        uint8Array.slice(12 + decompressedRleSection.length)
+      ]);
+
+      output = new Blob([outputBuffer], {
+        type: 'application/octet-stream'
+      });
+      break;
+    }
+    default: {
+      const outputBuffer = !hasCompressedTextures
+        ? textureBuffer
+        : compressTextureBuffer(textureBuffer);
+
+      output = new Blob([outputBuffer], {
+        type: 'application/octet-stream'
+      });
+      break;
+    }
+  }
+
   const link = document.createElement('a');
   link.href = window.URL.createObjectURL(output);
 

--- a/src/utils/textures/files/textureFileTypeMap.ts
+++ b/src/utils/textures/files/textureFileTypeMap.ts
@@ -1,0 +1,23 @@
+export type TextureFileType =
+  | 'mvc2-stage-preview'
+  | 'mvc2-character-portraits'
+  | 'mvc2-character-win'
+  | 'polygon-mapped'
+  | 'mvc2-end-file';
+
+export const CHARACTER_PORTRAITS_REGEX_FILE = /^PL[0-9A-Z]{2}_FAC.BIN$/i;
+export const MVC2_CHARACTER_WIN_REGEX_FILE = /^PL[0-9A-Z]{2}_WIN.BIN$/i;
+export const POLYGON_MAPPED_TEXTURE_FILE_REGEX =
+  /^(((STG|DM|DC)[0-9A-Z]{2})|EFKY)TEX(.modnao)?\.BIN$/i;
+export const MVC2_STAGE_PREVIEWS_FILE_REGEX = /^SELSTG\.BIN$/i;
+export const MVC2_END_FILE_REGEX = /^END(DC|NM)TEX\.BIN$/i;
+
+const textureFileTypeMap: Record<TextureFileType, RegExp> = {
+  'mvc2-character-portraits': CHARACTER_PORTRAITS_REGEX_FILE,
+  'mvc2-character-win': MVC2_CHARACTER_WIN_REGEX_FILE,
+  'mvc2-stage-preview': MVC2_STAGE_PREVIEWS_FILE_REGEX,
+  'mvc2-end-file': MVC2_END_FILE_REGEX,
+  'polygon-mapped': POLYGON_MAPPED_TEXTURE_FILE_REGEX
+};
+
+export default textureFileTypeMap;

--- a/src/utils/textures/parse/compressTextureBuffer.ts
+++ b/src/utils/textures/parse/compressTextureBuffer.ts
@@ -115,10 +115,6 @@ export default function compressTextureBuffer(buffer: Buffer) {
     }
   }
 
-  if (chunk !== 0) {
-    bitmasks.push(bitmask);
-  }
-
   chunk = 0;
   let bitmaskIndex = 0;
   let byteOffset = 0;
@@ -151,7 +147,8 @@ export default function compressTextureBuffer(buffer: Buffer) {
     chunk %= 16;
   }
 
-  outputBuffer = outputBuffer.subarray(0, byteOffset);
+  outputBuffer = outputBuffer.subarray(0, byteOffset + 2);
+  outputBuffer.writeUInt16LE(0, byteOffset);
 
   console.timeEnd('compressTextureBuffer');
   return outputBuffer;

--- a/src/utils/textures/parse/compressTextureBuffer.ts
+++ b/src/utils/textures/parse/compressTextureBuffer.ts
@@ -147,8 +147,12 @@ export default function compressTextureBuffer(buffer: Buffer) {
     chunk %= 16;
   }
 
-  outputBuffer = outputBuffer.subarray(0, byteOffset + 2);
-  outputBuffer.writeUInt16LE(0, byteOffset);
+  if (bitmask > 0) {
+    outputBuffer = outputBuffer.subarray(0, byteOffset + 2);
+    outputBuffer.writeUInt16LE(0, byteOffset);
+  } else {
+    outputBuffer = outputBuffer.subarray(0, byteOffset);
+  }
 
   console.timeEnd('compressTextureBuffer');
   return outputBuffer;

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -11,6 +11,7 @@ import {
 } from '@/utils/color-conversions';
 import { RgbaColor, TextureColorFormat } from '@/utils/textures';
 import { bufferToObjectUrl } from '@/utils/data';
+import { TextureFileType } from '../files/textureFileTypeMap';
 
 const COLOR_SIZE = 2;
 
@@ -105,6 +106,7 @@ export default async function loadTextureFile({
   textureDefs: NLTextureDef[];
   fileName: string;
   buffer: Buffer;
+  textureFileType: TextureFileType;
 }) {
   let result: Result;
   // @TODO: DRY regexp from useSupportedFilePicker

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -93,6 +93,7 @@ async function loadTextureBuffer(
 
 type Result = {
   textureDefs: NLTextureDef[];
+  textureFileType: TextureFileType;
   fileName: string;
   hasCompressedTextures: boolean;
   textureBufferUrl: string;
@@ -101,7 +102,8 @@ type Result = {
 export default async function loadTextureFile({
   buffer,
   textureDefs,
-  fileName
+  fileName,
+  textureFileType
 }: {
   textureDefs: NLTextureDef[];
   fileName: string;
@@ -125,6 +127,7 @@ export default async function loadTextureFile({
       textureBufferUrl: textureBufferUrl,
       hasCompressedTextures: false,
       fileName,
+      textureFileType,
       ...textureBufferData
     };
   } catch (error) {
@@ -148,6 +151,7 @@ export default async function loadTextureFile({
       textureBufferUrl: await bufferToObjectUrl(decompressedBuffer),
       fileName,
       hasCompressedTextures: true,
+      textureFileType,
       ...textureBufferData
     };
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,6 +5,7 @@ import adjustTextureHsl from './utils/textures/adjustTextureHsl';
 import { SourceTextureData } from './utils/textures/SourceTextureData';
 import TransferrableBuffer from './types/TransferrableBuffer';
 import loadPolygonFile from './utils/polygons/parse/loadPolygonFile';
+import { TextureFileType } from './utils/textures/files/textureFileTypeMap';
 
 export type WorkerEvent =
   | {
@@ -18,6 +19,7 @@ export type WorkerEvent =
       type: 'loadTextureFile';
       payload: {
         buffer: Buffer;
+        textureFileType: TextureFileType;
         textureDefs: NLTextureDef[];
         fileName: string;
         sourceTextureData: SourceTextureData;


### PR DESCRIPTION
Technically in this branch all logic for piecing together PL_FAC export is now supported, but disabled in the UI until a few nuances are sorted. Also contains some QOL fixes for better behavior when loading textures fail and minor style tweak for consistency in an edge case.

Merging early since this solves some edge cases in LZSS compression along the way for users who have reported issues that were already fixed.