### PR TITLE
Feature/support blender texture export

### DIFF
--- a/src/components/dialogs/file-support-info/FileSupportInfo.tsx
+++ b/src/components/dialogs/file-support-info/FileSupportInfo.tsx
@@ -109,7 +109,7 @@ const rows = [
     filenameFormat: 'DC{NN}POL.BIN',
     filenameExample: 'DC26POL.BIN',
     description: 'Menu/Gui polygons/models',
-    notes: `Corresponding textures are in similarly named TEX.BIN files.`
+    notes: `Corresponding textures are in similarly named TEX.BIN files. Exports become corrupt in game for unknown reason (perhaps cross reference check happens in-program).`
   },
   {
     title: 'Capcom vs SNK 2',

--- a/src/components/panel/GuiPanelModels.tsx
+++ b/src/components/panel/GuiPanelModels.tsx
@@ -37,7 +37,7 @@ const Styled = styled('div')(
   .supported-files {
     width: 100%;
     font-size: 8pt;
-    margin-top: -${theme.spacing(1)};
+    margin-top: -${theme.spacing(2)};
   }`
 );
 
@@ -221,17 +221,13 @@ export default function GuiPanelModels() {
         {
           <GuiPanelButton
             tooltip={
-              <div>
-                <p>
-                  Export a .gltf file representing the currently viewed in-scene model
-                  meshes.
-                </p>
-              </div>
+              'Export a .gltf file representing the currently viewed in-scene model ' +
+              'meshes and textures to import into Maya or Blender.'
             }
             onClick={onExportGLTFFile}
             color='secondary'
           >
-            Export Model .GLTF
+            Export Scene .GLTF
           </GuiPanelButton>
         }
         {exportSelectionButton}

--- a/src/components/panel/GuiPanelModels.tsx
+++ b/src/components/panel/GuiPanelModels.tsx
@@ -27,7 +27,7 @@ import {
   useAppSelector
 } from '@/store';
 import { useHeldRepetitionTimer, useModelSelectionExport } from '@/hooks';
-import useSceneOBJFileDownloader from '@/hooks/useSceneOBJDownloader';
+import useSceneGLTFFileDownloader from '@/hooks/useSceneOBJDownloader';
 import useSupportedFilePicker from '@/hooks/useSupportedFilePicker';
 import { mdiMenuLeftOutline, mdiMenuRightOutline } from '@mdi/js';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
@@ -49,7 +49,7 @@ export default function GuiPanelModels() {
 
   const objectKey = useAppSelector(selectObjectKey);
   const objectSelectionType = useAppSelector(selectObjectSelectionType);
-  const onExportOBJFile = useSceneOBJFileDownloader();
+  const onExportGLTFFile = useSceneGLTFFileDownloader();
   const onExportSelectionJson = useModelSelectionExport();
   const onSetObjectSelectionType = useCallback(
     (_: React.MouseEvent<HTMLElement>, type: 'mesh' | 'polygon') => {
@@ -218,22 +218,22 @@ export default function GuiPanelModels() {
           </Grid>
         </Grid>
         {importFiles}
-        {!viewOptions.devOptionsVisible ? undefined : (
+        {
           <GuiPanelButton
             tooltip={
               <div>
                 <p>
-                  Export an.obj file representing the selected in-scene model
+                  Export a .gltf file representing the currently viewed in-scene model
                   meshes.
                 </p>
               </div>
             }
-            onClick={onExportOBJFile}
+            onClick={onExportGLTFFile}
             color='secondary'
           >
-            Export Model .OBJ
+            Export Model .GLTF
           </GuiPanelButton>
-        )}
+        }
         {exportSelectionButton}
       </div>
     </GuiPanelSection>

--- a/src/components/scene/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas.tsx
@@ -35,7 +35,6 @@ import {
   DataTexture,
   RepeatWrapping,
   RGBAFormat,
-  sRGBEncoding,
   UnsignedByteType,
   Vector2
 } from 'three';
@@ -46,7 +45,7 @@ THREE.ColorManagement.enabled = true;
 
 const cameraParams = { far: 5000000 };
 
-const TEXTURE_ROTATION = (90 * Math.PI) / 180;
+const TEXTURE_ROTATION = 1.5708;
 const TEXTURE_CENTER = new Vector2(0.5, 0.5);
 
 const useClientLayoutEffect =
@@ -64,8 +63,19 @@ async function createTextureFromObjectUrl(
     width,
     height,
     RGBAFormat,
-    UnsignedByteType
+    UnsignedByteType,
+    THREE.Texture.DEFAULT_MAPPING,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    THREE.SRGBColorSpace
   );
+  texture.rotation = TEXTURE_ROTATION;
+  texture.center = TEXTURE_CENTER;
+  texture.repeat.y = -1;
+  texture.flipY = false;
   texture.needsUpdate = true;
 
   return texture;
@@ -127,15 +137,6 @@ export default function SceneCanvas() {
                     t.width,
                     t.height
                   );
-
-                  baseTexture.rotation = TEXTURE_ROTATION;
-                  baseTexture.center = TEXTURE_CENTER;
-                  baseTexture.repeat.y = -1;
-
-                  // addresses an issue in ThreeJS with
-                  // sRGB randomly not applying to textures depending
-                  // on how it is created
-                  baseTexture.encoding = sRGBEncoding;
                 }
 
                 const texture =

--- a/src/contexts/SceneContext.tsx
+++ b/src/contexts/SceneContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useState
 } from 'react';
-import { Scene } from 'three';
+import { SRGBColorSpace, Scene } from 'three';
 
 type SceneContextOptions = {
   scene: Scene | undefined;
@@ -28,10 +28,16 @@ export function useSceneContext() {
 // this stub component to retrieve what we need
 export function SceneContextSetup() {
   const { setScene } = useContext(SceneContext);
-  const { scene } = useThree();
+  const { scene, gl } = useThree();
   useEffect(() => {
     setScene(scene);
   }, [scene]);
+  
+  useEffect(() => {
+    if(gl) {
+      gl.outputColorSpace = SRGBColorSpace;
+    }
+  }, [gl]);
 
   return <></>;
 }

--- a/src/hooks/useSceneOBJDownloader.ts
+++ b/src/hooks/useSceneOBJDownloader.ts
@@ -1,29 +1,71 @@
 import { useSceneContext } from '@/contexts/SceneContext';
 import { useAppSelector } from '@/store';
 import { useCallback } from 'react';
-import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter.js';
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
 
-const exporter = new OBJExporter();
+async function rotateDataUri(dataURI: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const img = new Image();
+    img.src = dataURI;
 
-export default function useSceneOBJFileDownloader() {
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+
+      const width = img.height;
+      const height = img.width;
+
+      canvas.width = width;
+      canvas.height = height;
+
+      ctx.translate(canvas.width / 2, canvas.height / 2);
+      ctx.rotate((90 * Math.PI) / 180);
+      ctx.scale(1, -1);
+      ctx.drawImage(img, -width / 2, -height / 2);
+
+      const rotatedDataURI = canvas.toDataURL();
+      resolve(rotatedDataURI);
+    };
+
+    img.onerror = (error) => {
+      reject(error);
+    };
+  });
+}
+
+const exporter = new GLTFExporter();
+
+type GLTFImage = {
+  uri: string;
+};
+
+export default function useSceneGLTFFileDownloader() {
   const { scene } = useSceneContext();
   const polygonFileName =
     useAppSelector((s) => s.modelData.polygonFileName) || '';
 
-  const onDownloadSceneOBJFile = useCallback(() => {
+  const onDownloadSceneFile = useCallback(async () => {
     if (!scene) {
-      throw new Error('no scene instantiated to get OBJ file');
+      throw new Error('no scene instantiated to get GLTF file');
     }
 
-    const output = exporter.parse(scene);
+    const output = await exporter.parseAsync(scene) as { images: GLTFImage[] };
 
-    const file = new Blob([output], { type: 'application/object' });
+    const rotationPromises = output.images.map(async (img) => {
+      const uri = await rotateDataUri(img.uri);
+      return { ...img, uri };
+    });
+    
+    const rotatedImages = await Promise.all(rotationPromises);    
+    output.images = rotatedImages;
+   
+    const file = new Blob([JSON.stringify(output, null, 2)], { type: 'application/object' });
     const link = document.createElement('a');
     link.href = window.URL.createObjectURL(file);
     const name = polygonFileName.substring(0, polygonFileName.lastIndexOf('.'));
-    link.download = `${name}.modnao.obj`;
+    link.download = `${name}.mn.gltf`;
     link.click();
   }, [scene]);
 
-  return onDownloadSceneOBJFile;
+  return onDownloadSceneFile;
 }

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -134,6 +134,6 @@ export default async function exportTextureFile({
   const extension = textureFileName.substring(
     textureFileName.lastIndexOf('.') + 1
   );
-  link.download = `${name}.modnao.${extension}`;
+  link.download = `${name}.mn.${extension}`;
   link.click();
 }

--- a/src/utils/textures/files/textureFileTypeMap.ts
+++ b/src/utils/textures/files/textureFileTypeMap.ts
@@ -8,7 +8,7 @@ export type TextureFileType =
 export const CHARACTER_PORTRAITS_REGEX_FILE = /^PL[0-9A-Z]{2}_FAC.BIN$/i;
 export const MVC2_CHARACTER_WIN_REGEX_FILE = /^PL[0-9A-Z]{2}_WIN.BIN$/i;
 export const POLYGON_MAPPED_TEXTURE_FILE_REGEX =
-  /^((((STG|DM|DC)[0-9A-Z]{2})|EFKY)|(STGE[0-9]{1}))TEX(.modnao)?\.BIN$/i;
+  /^((((STG|DM|DC)[0-9A-Z]{2})|EFKY)|(STGE[0-9]{1}))TEX(.mn)?\.BIN$/i;
 export const MVC2_STAGE_PREVIEWS_FILE_REGEX = /^SELSTG\.BIN$/i;
 export const MVC2_END_FILE_REGEX = /^END(DC|NM)TEX\.BIN$/i;
 


### PR DESCRIPTION
Support texture exports in Blender. Now using GLTF vs OBJ files so that textures can be embedded.

GUI Panel
![image](https://github.com/rob2d/modnao/assets/1799905/dc1588a6-eb7f-4998-a881-e801e11f581e)

Viewing the exported GLTF within Blender
![image](https://github.com/rob2d/modnao/assets/1799905/6504c38f-c1d5-4212-9719-45616960b529)
