### PR TITLE
quantize colors for certain compressed images to fit in designated RAM areas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "nanoid": "^4.0.2",
         "next": "^13.4.7",
         "prettier": "^2.8.8",
+        "quanti": "^1.0.8",
         "react-color": "^2.19.3",
         "react-dropzone": "^14.2.3",
         "react-easy-crop": "^5.0.0",
@@ -12558,6 +12559,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/quanti": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/quanti/-/quanti-1.0.8.tgz",
+      "integrity": "sha512-zaFITfyju5B/ic/YMnUWzWSE/2JYY4rrABwFhkMu5A4KxasyAy91JPlYyBxJA97IzPUs80BNndmXzlQTa6rdHA==",
+      "dev": true
     },
     "node_modules/querystringify": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "nanoid": "^4.0.2",
     "next": "^13.4.7",
     "prettier": "^2.8.8",
+    "quanti": "^1.0.8",
     "react-color": "^2.19.3",
     "react-dropzone": "^14.2.3",
     "react-easy-crop": "^5.0.0",

--- a/src/components/dialogs/file-support-info/FileSupportInfo.tsx
+++ b/src/components/dialogs/file-support-info/FileSupportInfo.tsx
@@ -45,9 +45,8 @@ const rows = [
     filenameFormat: 'PL{NN}_FAC.BIN',
     filenameExample: 'PL0D_FAC.BIN',
     description: 'Player lifebars, superportraits (both Japanese & US/International)',
-    hasIssues: true,
     notes:
-      'Superportraits not yet supported, but content viewable this file can be edited. If errors exist, reduce the number of colors since compression needs iteration to get file size down within guaranteed acceptable limit.'
+      'Superportraits not yet supported, but content viewable this file can be edited. Palette will be limited (handled automatically on export).'
   },
   {
     title: 'Marvel vs Capcom 2',
@@ -60,7 +59,7 @@ const rows = [
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'SELSTG.BIN',
     filenameExample: 'SELSTG.BIN',
-    description: 'Stage select screen previews',
+    description: 'Stage select screen previews.',
     notes: ''
   },
   {
@@ -68,8 +67,7 @@ const rows = [
     filenameFormat: 'SELTEX.BIN',
     filenameExample: 'SELTEX.BIN',
     description: 'Stage select screen textures',
-    notes: 'File size must be within original size limit; may need to reduce color details until compression has been optimized further',
-    hasIssues: true
+    notes: 'Palette will be limited to fit within size limits (handled automatically on export).'
   },
   {
     title: 'Capcom vs SNK 2',
@@ -80,7 +78,7 @@ const rows = [
   },
   {
     title: 'Capcom vs SNK 2',
-    filenameFormat: 'STG{NN}TEX.BIN',
+    filenameFormat: 'STG{NN}(E)TEX.BIN',
     filenameExample: 'STG02TEX.BIN',
     description: 'Stage textures',
     notes: `Must be loaded with a corresponding POL.BIN file.`
@@ -94,10 +92,10 @@ const rows = [
   },
   {
     title: 'Capcom vs SNK 2',
-    filenameFormat: 'DC{NN}TEX.BIN',
+    filenameFormat: 'DC(E){NN}TEX.BIN',
     filenameExample: 'DC02TEX.BIN',
     description: 'Menu/Gui textures',
-    notes: `Must be loaded with a corresponding POL.BIN file. Certain files are not able to load due to VQ sections, and may need to reduce number of colors if receiving export error due to current compression limitations.`,
+    notes: `Must be loaded with a corresponding POL.BIN file. Certain files are not able to load due to VQ sections, palette will be limited on export.`,
     hasIssues: true
   }
 ].map((r, id) => ({ ...r, id }));

--- a/src/hooks/useSupportedFilePicker.spec.ts
+++ b/src/hooks/useSupportedFilePicker.spec.ts
@@ -47,7 +47,6 @@ describe('handleFileInput', () => {
       getMockFilesWithNames(['DM01POL.BIN', 'DM01TEX.BIN']),
       ...restParams
     );
-
     await handleFileInput(
       getMockFilesWithNames(['DM01POL.BIN']),
       ...restParams

--- a/src/hooks/useSupportedFilePicker.ts
+++ b/src/hooks/useSupportedFilePicker.ts
@@ -16,7 +16,7 @@ import textureFileTypeMap, {
 } from '@/utils/textures/files/textureFileTypeMap';
 
 /** polygon files which may be associated to textures */
-export const POLYGON_FILE = /^(((STG|DM|DC)[0-9A-Z]{2})|EFKY)POL\.BIN$/i;
+export const POLYGON_FILE = /^(((STG|DM|DC)[0-9A-Z]{2})|EFKY)POL.BIN$/i;
 
 const dedicatedTextureKVs = Object.entries(textureFileTypeMap).filter(
   ([k]) => k !== 'polygon-mapped'

--- a/src/utils/textures/files/textureFileTypeMap.ts
+++ b/src/utils/textures/files/textureFileTypeMap.ts
@@ -9,7 +9,7 @@ export type TextureFileType =
 export const CHARACTER_PORTRAITS = /^PL[0-9A-Z]{2}_FAC(.mn)?.BIN$/i;
 export const MVC2_CHARACTER_WIN = /^PL[0-9A-Z]{2}_WIN(.mn)?.BIN$/i;
 export const POLYGON_MAPPED_TEXTURE =
-/^((((STG(E)?|DM)[0-9A-Z]{2})|EFKY))|(DC[0-9A-Z]{2}(E)?)TEX(.mn)?.BIN$/i;
+/^(((((STG(E)?|DM)[0-9A-Z]{2})|EFKY))|(DC[0-9A-Z]{2}(E)?))TEX(.mn)?.BIN$/
 export const MVC2_STAGE_PREVIEWS = /^SELSTG(.mn)?.BIN$/i;
 export const MVC2_SELECTION_TEXTURES = /^SELTEX(.mn)?.BIN$/i;
 export const MVC2_END_ART = /^END(DC|NM)TEX(.mn)?.BIN$/i;


### PR DESCRIPTION
Allows for users not to worry about whether a file fits within necessary file size limits that may overflow RAM boundaries for specific graphics edited.