### PR TITLE
base-dedicated texture view

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,12 +6,6 @@
   ],
   "plugins": ["import", "prettier"],
   "rules": {
-    "prefer-const": [
-      "error",
-      {
-        "auto": false
-      }
-    ],
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "react-hooks/exhaustive-deps": 0,
     "sort-imports": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,8 @@
         "react-redux": "^8.0.5",
         "three": "^0.150.1",
         "use-debounce": "^9.0.4",
-        "use-file-picker": "^1.6.1"
+        "use-file-picker": "^1.6.1",
+        "use-viewport-sizes": "^0.7.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -14169,6 +14170,15 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-viewport-sizes": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/use-viewport-sizes/-/use-viewport-sizes-0.7.2.tgz",
+      "integrity": "sha512-wUNStIIr2q3wIY2AymQrHSFdkqhftjCxYnDDJnyYF9T0cm2fS4qOB1SFMKtECxKw7+bWJR6AAjIoqpmA6GcqpQ==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/utif2": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react-redux": "^8.0.5",
     "three": "^0.150.1",
     "use-debounce": "^9.0.4",
-    "use-file-picker": "^1.6.1"
+    "use-file-picker": "^1.6.1",
+    "use-viewport-sizes": "^0.7.2"
   }
 }

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useContext } from 'react';
 import clsx from 'clsx';
 import GuiPanel from './panel/GuiPanel';
 import SceneView from './SceneView';
-import { Button, Paper, styled, Tooltip, Typography } from '@mui/material';
+import { Button, Paper, styled, Tooltip } from '@mui/material';
 import Icon from '@mdi/react';
 import { mdiInformationOutline } from '@mdi/js';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
@@ -96,14 +96,12 @@ export default function MainView() {
   const contentViewMode = useAppSelector(selectContentViewMode);
   let mainScene;
 
-  switch(contentViewMode) {
-    case 'polygons': 
+  switch (contentViewMode) {
+    case 'polygons':
       mainScene = <SceneView />;
       break;
     case 'textures':
-      mainScene = (
-        <TextureView />
-      );
+      mainScene = <TextureView />;
       break;
     default:
       mainScene = (

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -8,8 +8,7 @@ import { mdiInformationOutline } from '@mdi/js';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import { AppDialog, AppInfo } from './dialogs';
 import {
-  selectHasLoadedFile,
-  selectHasLoadedPolygonFile,
+  selectContentViewMode,
   showDialog,
   useAppDispatch,
   useAppSelector
@@ -94,38 +93,41 @@ export default function MainView() {
     dispatch(showDialog('app-info'));
   }, [dispatch]);
 
-  const hasLoadedFileValue = useAppSelector(selectHasLoadedFile);
-  const hasLoadedPolygonFile = useAppSelector(selectHasLoadedPolygonFile);
-  const hasLoadedFile = useDebounce(hasLoadedFileValue, 500);
+  const contentViewModeValue = useAppSelector(selectContentViewMode);
+  const contentViewMode = useDebounce(contentViewModeValue, 500);
   let mainScene;
 
-  if (hasLoadedFile) {
-    mainScene = hasLoadedPolygonFile ? (
-      <SceneCanvas />
-    ) : (
-      <div className='welcome-panel'>
-        <Typography variant='h6'>Texture-only mode</Typography>
-        <Typography variant='subtitle2'>
-          No associated polygon/model files with these textures to display a
-          scene.
-        </Typography>
-      </div>
-    );
-  } else {
-    mainScene = (
-      <div className='welcome-panel'>
-        <Paper variant='outlined'>
-          <AppInfo />
-        </Paper>
-      </div>
-    );
+  switch(contentViewMode) {
+    case 'polygons': 
+      mainScene = <SceneCanvas />;
+      break;
+    case 'textures':
+      mainScene = (
+        <div className='welcome-panel'>
+          <Typography variant='h6'>Texture-only mode</Typography>
+          <Typography variant='subtitle2'>
+            No associated polygon/model files with these textures to display a
+            scene.
+          </Typography>
+        </div>
+      );
+      break;
+    default:
+      mainScene = (
+        <div className='welcome-panel'>
+          <Paper variant='outlined'>
+            <AppInfo />
+          </Paper>
+        </div>
+      );
+      break;
   }
 
   return (
     <Styled>
       <div>
         {mainScene}
-        {!hasLoadedFile ? undefined : (
+        {contentViewMode === 'welcome' ? undefined : (
           <Tooltip
             title='View app info and usage tips'
             disableInteractive={!guiPanelVisible}

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -13,7 +13,6 @@ import {
   useAppDispatch,
   useAppSelector
 } from '@/store';
-import { useDebounce } from '@uidotdev/usehooks';
 
 const Styled = styled('main')(
   ({ theme }) => `
@@ -93,8 +92,7 @@ export default function MainView() {
     dispatch(showDialog('app-info'));
   }, [dispatch]);
 
-  const contentViewModeValue = useAppSelector(selectContentViewMode);
-  const contentViewMode = useDebounce(contentViewModeValue, 500);
+  const contentViewMode = useAppSelector(selectContentViewMode);
   let mainScene;
 
   switch(contentViewMode) {

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext } from 'react';
 import clsx from 'clsx';
 import GuiPanel from './panel/GuiPanel';
-import SceneCanvas from './scene/SceneCanvas';
+import SceneView from './SceneView';
 import { Button, Paper, styled, Tooltip, Typography } from '@mui/material';
 import Icon from '@mdi/react';
 import { mdiInformationOutline } from '@mdi/js';
@@ -13,6 +13,7 @@ import {
   useAppDispatch,
   useAppSelector
 } from '@/store';
+import TextureView from './TextureView';
 
 const Styled = styled('main')(
   ({ theme }) => `
@@ -97,17 +98,11 @@ export default function MainView() {
 
   switch(contentViewMode) {
     case 'polygons': 
-      mainScene = <SceneCanvas />;
+      mainScene = <SceneView />;
       break;
     case 'textures':
       mainScene = (
-        <div className='welcome-panel'>
-          <Typography variant='h6'>Texture-only mode</Typography>
-          <Typography variant='subtitle2'>
-            No associated polygon/model files with these textures to display a
-            scene.
-          </Typography>
-        </div>
+        <TextureView />
       );
       break;
     default:

--- a/src/components/SceneView.tsx
+++ b/src/components/SceneView.tsx
@@ -13,9 +13,9 @@ import { OrbitControls } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 import {
   selectDisplayedMeshes,
+  selectMeshSelectionType,
   selectModel,
   selectObjectKey,
-  selectMeshSelectionType,
   selectSceneTextureDefs,
   selectUneditedTextureUrls
 } from '@/store/selectors';
@@ -198,9 +198,7 @@ export default function SceneView() {
           <RenderedPolygon
             {...p}
             key={`${m.address}_${p.address}`}
-            objectKey={
-              meshSelectionType === 'mesh' ? `${i}` : `${i}_${pIndex}`
-            }
+            objectKey={meshSelectionType === 'mesh' ? `${i}` : `${i}_${pIndex}`}
             selectedObjectKey={objectKey}
             onSelectObjectKey={onSelectObjectKey}
             texture={texture}

--- a/src/components/SceneView.tsx
+++ b/src/components/SceneView.tsx
@@ -20,7 +20,7 @@ import {
   selectUneditedTextureUrls
 } from '@/store/selectors';
 import { setObjectKey, useAppDispatch, useAppSelector } from '@/store';
-import { useSceneKeyboardControls } from '@/hooks';
+import { useObjectNavControls } from '@/hooks';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import { useTheme } from '@mui/material';
 import { SceneContextSetup } from '@/contexts/SceneContext';
@@ -39,7 +39,7 @@ import {
   Vector2
 } from 'three';
 import { objectUrlToBuffer } from '@/utils/data';
-import RenderedPolygon from './RenderedPolygon';
+import RenderedPolygon from './scene/RenderedPolygon';
 
 THREE.ColorManagement.enabled = true;
 
@@ -83,8 +83,8 @@ async function createTextureFromObjectUrl(
 
 const axesHelper = <axesHelper args={[50]} />;
 
-export default function SceneCanvas() {
-  useSceneKeyboardControls();
+export default function SceneView() {
+  useObjectNavControls();
   const [textureMap, setTextureMap] = useState<Map<string, DataTexture>>();
   const canvasRef = useRef() as MutableRefObject<HTMLCanvasElement>;
   const viewOptions = useContext(ViewOptionsContext);

--- a/src/components/TextureView.tsx
+++ b/src/components/TextureView.tsx
@@ -1,0 +1,9 @@
+import { useObjectNavControls } from '@/hooks';
+
+export default function TextureView() {
+    useObjectNavControls();
+    
+    return (
+        <div>Texture View</div>
+    );
+}

--- a/src/components/TextureView.tsx
+++ b/src/components/TextureView.tsx
@@ -1,9 +1,39 @@
+import { Skeleton, styled } from '@mui/material';
+import Img from 'next/image';
+import useViewportSizes from 'use-viewport-sizes';
 import { useObjectNavControls } from '@/hooks';
+import { selectTextureDefs, selectTextureIndex, useAppSelector } from '@/store';
+
+const Styled = styled('div')(
+  ({ theme }) =>
+    `& {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      align-items: center;
+      justify-content: center;
+    }
+    
+    & .texture-preview {
+      transform: rotate(-90deg);
+    }`
+);
 
 export default function TextureView() {
-    useObjectNavControls();
-    
-    return (
-        <div>Texture View</div>
-    );
+  useObjectNavControls();
+  const [vpW] = useViewportSizes();
+  const size = Math.round((vpW - 222) * 0.66);
+  const textureIndex = useAppSelector(selectTextureIndex);
+  const textureDefs = useAppSelector(selectTextureDefs);
+  const textureUrl = textureDefs?.[textureIndex]?.dataUrls?.opaque;
+
+  return (
+    <Styled>
+      {
+        !textureUrl ? 
+          <Skeleton className='texture-preview' variant='rectangular' width={size} height={size} /> : 
+          <Img alt='texture preview' className='texture-preview' width={size} height={size} src={textureUrl} />
+      }
+    </Styled>
+  );
 }

--- a/src/components/TextureView.tsx
+++ b/src/components/TextureView.tsx
@@ -1,26 +1,54 @@
-import { Skeleton, styled } from '@mui/material';
+import { IconButton, Skeleton, styled } from '@mui/material';
+import { mdiMenuLeftOutline, mdiMenuRightOutline } from '@mdi/js';
+import Icon from '@mdi/react';
 import Img from 'next/image';
 import useViewportSizes from 'use-viewport-sizes';
-import { useObjectNavControls } from '@/hooks';
+import { useObjectNavControls, useObjectUINav } from '@/hooks';
 import { selectTextureDefs, selectTextureIndex, useAppSelector } from '@/store';
 
 const Styled = styled('div')(
-  ({ theme }) =>
+  () =>
     `& {
       display: flex;
       flex-direction: column;
       flex-grow: 1;
       align-items: center;
       justify-content: center;
+      max-height:100vh;
+      overflow-y: hidden;
+    }
+
+    & .main-preview {
+      display: grid;
+      flex-grow: 1;
+      grid-template-columns: min-content auto min-content;
+    }
+
+    & .main-preview > * {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    & .controls-panel {
+      display: flex;
+      flex-shrink: 0;
+    }
+
+    & .texture-preview {
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
     
-    & .texture-preview {
+    & .texture-preview > img {
       transform: rotate(-90deg);
     }`
 );
 
 export default function TextureView() {
   useObjectNavControls();
+  const uiControls = useObjectUINav();
   const [vpW] = useViewportSizes();
   const size = Math.round((vpW - 222) * 0.66);
   const textureIndex = useAppSelector(selectTextureIndex);
@@ -29,11 +57,43 @@ export default function TextureView() {
 
   return (
     <Styled>
-      {
-        !textureUrl ? 
-          <Skeleton className='texture-preview' variant='rectangular' width={size} height={size} /> : 
-          <Img alt='texture preview' className='texture-preview' width={size} height={size} src={textureUrl} />
-      }
+      <div className='main-preview'>
+        <IconButton
+          className='model-nav-button'
+          color='primary'
+          aria-haspopup='true'
+          {...uiControls.prevButtonProps}
+        >
+          <Icon path={mdiMenuLeftOutline} size={2} />
+        </IconButton>
+        <div className='texture-preview'>
+          {!textureUrl ? (
+            <Skeleton
+              className='texture-preview'
+              variant='rectangular'
+              width={size}
+              height={size}
+            />
+          ) : (
+            <Img
+              alt='texture preview'
+              className='texture-preview'
+              width={size}
+              height={size}
+              src={textureUrl}
+            />
+          )}
+        </div>
+        <IconButton
+          className='model-nav-button'
+          color='primary'
+          aria-haspopup='true'
+          {...uiControls.nextButtonProps}
+        >
+          <Icon path={mdiMenuRightOutline} size={2} />
+        </IconButton>
+      </div>
+      <div className='controls-panel'></div>
     </Styled>
   );
 }

--- a/src/components/dialogs/file-support-info/FileSupportInfo.tsx
+++ b/src/components/dialogs/file-support-info/FileSupportInfo.tsx
@@ -44,7 +44,8 @@ const rows = [
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'PL{NN}_FAC.BIN',
     filenameExample: 'PL0D_FAC.BIN',
-    description: 'Player lifebars, superportraits (both Japanese & US/International)',
+    description:
+      'Player lifebars, superportraits (both Japanese & US/International)',
     notes:
       'Superportraits not yet supported, but content viewable this file can be edited. Palette will be limited (handled automatically on export).'
   },
@@ -67,7 +68,8 @@ const rows = [
     filenameFormat: 'SELTEX.BIN',
     filenameExample: 'SELTEX.BIN',
     description: 'Stage select screen textures',
-    notes: 'Palette will be limited to fit within size limits (handled automatically on export).'
+    notes:
+      'Palette will be limited to fit within size limits (handled automatically on export).'
   },
   {
     title: 'Capcom vs SNK 2',
@@ -121,7 +123,8 @@ const Styled = styled('div')(
     }`
 );
 
-const redIssueCellClassName = (params: GridCellParams) => clsx(params.row.hasIssues ? 'has-issues' : '');
+const redIssueCellClassName = (params: GridCellParams) =>
+  clsx(params.row.hasIssues ? 'has-issues' : '');
 
 const columns: GridColDef[] = [
   {

--- a/src/components/panel/GuiPanel.tsx
+++ b/src/components/panel/GuiPanel.tsx
@@ -13,7 +13,7 @@ import {
   useAppSelector
 } from '@/store';
 
-const WIDTH = 222;
+const PANEL_WIDTH = 222;
 
 const TRANSITION_TIME = `0.32s`;
 
@@ -33,7 +33,7 @@ const StyledPaper = styled(Paper)(
     }
 
     &.MuiPaper-root.visible {
-      width: ${WIDTH}px;
+      width: ${PANEL_WIDTH}px;
       flex-shrink: 0;
     }
 
@@ -47,7 +47,7 @@ const StyledPaper = styled(Paper)(
       position: absolute;
       top: 0;
       left: 0;
-      width: ${WIDTH}px;
+      width: ${PANEL_WIDTH}px;
       height: 100vh;
       flex-shrink: 0;
       

--- a/src/components/panel/GuiPanel.tsx
+++ b/src/components/panel/GuiPanel.tsx
@@ -7,9 +7,9 @@ import GuiPanelViewOptions from './GuiPanelViewOptions';
 import GuiPanelTextures from './GuiPanelTextures';
 import GuiPanelModels from './GuiPanelModels';
 import {
+  selectContentViewMode,
   selectHasLoadedPolygonFile,
   selectHasLoadedTextureFile,
-  selectContentViewMode,
   useAppSelector
 } from '@/store';
 
@@ -157,7 +157,7 @@ export default function GuiPanel() {
       <div className='content'>
         {contentViewMode !== 'welcome' ? undefined : (
           <Img alt='logo' src='/logo.svg' width={222} height={172} />
-        ) }
+        )}
         {contentViewMode !== 'textures' ? (
           <>
             <GuiPanelModels />

--- a/src/components/panel/GuiPanel.tsx
+++ b/src/components/panel/GuiPanel.tsx
@@ -9,6 +9,7 @@ import GuiPanelModels from './GuiPanelModels';
 import {
   selectHasLoadedPolygonFile,
   selectHasLoadedTextureFile,
+  selectContentViewMode,
   useAppSelector
 } from '@/store';
 
@@ -144,9 +145,9 @@ const StyledPaper = styled(Paper)(
 
 export default function GuiPanel() {
   const viewOptions = useContext(ViewOptionsContext);
+  const contentViewMode = useAppSelector(selectContentViewMode);
   const hasLoadedTextureFile = useAppSelector(selectHasLoadedTextureFile);
   const hasLoadedPolygonFile = useAppSelector(selectHasLoadedPolygonFile);
-  const isTextureOnlyMode = hasLoadedTextureFile && !hasLoadedPolygonFile;
 
   return (
     <StyledPaper
@@ -154,10 +155,10 @@ export default function GuiPanel() {
       className={clsx(viewOptions.guiPanelVisible && 'visible')}
     >
       <div className='content'>
-        {!hasLoadedPolygonFile && !hasLoadedTextureFile ? (
+        {contentViewMode !== 'welcome' ? undefined : (
           <Img alt='logo' src='/logo.svg' width={222} height={172} />
-        ) : undefined}
-        {!isTextureOnlyMode ? (
+        ) }
+        {contentViewMode !== 'textures' ? (
           <>
             <GuiPanelModels />
             {!hasLoadedTextureFile ? undefined : (

--- a/src/components/panel/GuiPanelModels.tsx
+++ b/src/components/panel/GuiPanelModels.tsx
@@ -11,24 +11,25 @@ import Icon from '@mdi/react';
 import Grid from '@mui/material/Unstable_Grid2';
 import GuiPanelButton from './GuiPanelButton';
 import GuiPanelSection from './GuiPanelSection';
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import {
-  navToNextObject,
-  navToPrevObject,
+  selectMeshSelectionType,
   selectModel,
   selectModelCount,
   selectModelIndex,
   selectObjectKey,
-  selectMeshSelectionType,
   selectPolygonFileName,
   setObjectType,
   showDialog,
   useAppDispatch,
   useAppSelector
 } from '@/store';
-import { useHeldRepetitionTimer, useModelSelectionExport } from '@/hooks';
-import useSceneGLTFFileDownloader from '@/hooks/useSceneOBJDownloader';
-import useSupportedFilePicker from '@/hooks/useSupportedFilePicker';
+import {
+  useModelSelectionExport,
+  useObjectUINav,
+  useSceneGLTFFileDownloader,
+  useSupportedFilePicker
+} from '@/hooks';
 import { mdiMenuLeftOutline, mdiMenuRightOutline } from '@mdi/js';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 
@@ -46,6 +47,7 @@ export default function GuiPanelModels() {
   const dispatch = useAppDispatch();
   // @TODO use a more standard error dialog vs using window.alert here
   const openFileSelector = useSupportedFilePicker(globalThis.alert);
+  const uiNav = useObjectUINav();
 
   const objectKey = useAppSelector(selectObjectKey);
   const meshSelectionType = useAppSelector(selectMeshSelectionType);
@@ -99,29 +101,6 @@ export default function GuiPanelModels() {
     viewOptions.devOptionsVisible
   ]);
 
-  const [onStartPrevModelNav, onStopPrevModelNav] = useHeldRepetitionTimer();
-  const [onStartNextModelNav, onStopNextModelNav] = useHeldRepetitionTimer();
-
-  useEffect(() => {
-    window.addEventListener('mouseup', onStopPrevModelNav);
-    window.addEventListener('mouseup', onStopNextModelNav);
-    return () => {
-      window.removeEventListener('mouseup', onStopPrevModelNav);
-      window.removeEventListener('mouseup', onStopNextModelNav);
-    };
-  }, []);
-  const onStartModelPrevClick = useCallback(() => {
-    onStartPrevModelNav(() => {
-      dispatch(navToPrevObject());
-    });
-  }, [modelIndex]);
-
-  const onStartModelNextClick = useCallback(() => {
-    onStartNextModelNav(() => {
-      dispatch(navToNextObject());
-    });
-  }, [modelIndex]);
-
   let modelNoAndCount = '--';
 
   if (model) {
@@ -167,9 +146,8 @@ export default function GuiPanelModels() {
               className='model-nav-button'
               color='primary'
               aria-haspopup='true'
-              onMouseDown={onStartModelPrevClick}
-              onMouseUp={onStopPrevModelNav}
-              disabled={!model || modelIndex === 0}
+              {...uiNav.prevButtonProps}
+              disabled={!model || uiNav.prevButtonProps.disabled}
             >
               <Icon path={mdiMenuLeftOutline} size={1} />
             </IconButton>
@@ -180,9 +158,8 @@ export default function GuiPanelModels() {
               className='model-nav-button'
               color='primary'
               aria-haspopup='true'
-              onMouseDown={onStartModelNextClick}
-              onMouseUp={onStopNextModelNav}
-              disabled={!model || modelIndex === modelCount - 1}
+              {...uiNav.nextButtonProps}
+              disabled={!model || uiNav.prevButtonProps.disabled}
             >
               <Icon path={mdiMenuRightOutline} size={1} />
             </IconButton>

--- a/src/components/panel/GuiPanelTextures.tsx
+++ b/src/components/panel/GuiPanelTextures.tsx
@@ -3,17 +3,17 @@ import { useCallback, useEffect, useMemo } from 'react';
 import {
   downloadTextureFile,
   selectCanExportTextures,
+  selectContentViewMode,
+  selectHasLoadedTextureFile,
   selectModel,
   selectModels,
   selectObjectMeshIndex,
   selectObjectPolygonIndex,
   selectSceneTextureDefs,
-  selectTextureFileName,
   selectSelectedTexture,
+  selectTextureFileName,
   useAppDispatch,
-  useAppSelector,
-  selectContentViewMode,
-  selectHasLoadedTextureFile
+  useAppSelector
 } from '@/store';
 import GuiPanelButton from './GuiPanelButton';
 import GuiPanelTexture from './textures/GuiPanelTexture';
@@ -49,9 +49,7 @@ export default function GuiPanelViewOptions() {
 
   // when selecting a texture, scroll to the item
   useEffect(() => {
-    const textureEl = document.getElementById(
-      `gui-panel-t-${selectedTexture}`
-    );
+    const textureEl = document.getElementById(`gui-panel-t-${selectedTexture}`);
 
     if (textureEl) {
       textureEl.scrollIntoView({ behavior: 'smooth' });
@@ -112,11 +110,20 @@ export default function GuiPanelViewOptions() {
     }
 
     return [pTextures, opTextures];
-  }, [model, meshIndex, textureDefs, selectedTexture, polygonIndex, contentViewMode]);
+  }, [
+    model,
+    meshIndex,
+    textureDefs,
+    selectedTexture,
+    polygonIndex,
+    contentViewMode
+  ]);
 
   return (
-    <GuiPanelSection 
-      title={`Textures ${hasLoadedTextureFile ? ` (${textureDefs.length})` : ''}`} 
+    <GuiPanelSection
+      title={`Textures ${
+        hasLoadedTextureFile ? ` (${textureDefs.length})` : ''
+      }`}
       subtitle={textureFileName}
     >
       <Styled className='textures'>

--- a/src/components/panel/GuiPanelTextures.tsx
+++ b/src/components/panel/GuiPanelTextures.tsx
@@ -12,7 +12,8 @@ import {
   selectSelectedTexture,
   useAppDispatch,
   useAppSelector,
-  selectContentViewMode
+  selectContentViewMode,
+  selectHasLoadedTextureFile
 } from '@/store';
 import GuiPanelButton from './GuiPanelButton';
 import GuiPanelTexture from './textures/GuiPanelTexture';
@@ -41,6 +42,7 @@ export default function GuiPanelViewOptions() {
   const textureFileName = useAppSelector(selectTextureFileName);
   const selectedTexture = useAppSelector(selectSelectedTexture);
   const contentViewMode = useAppSelector(selectContentViewMode);
+  const hasLoadedTextureFile = useAppSelector(selectHasLoadedTextureFile);
   const models = useAppSelector(selectModels);
 
   const polygonIndex = useAppSelector(selectObjectPolygonIndex);
@@ -113,7 +115,10 @@ export default function GuiPanelViewOptions() {
   }, [model, meshIndex, textureDefs, selectedTexture, polygonIndex, contentViewMode]);
 
   return (
-    <GuiPanelSection title='Textures' subtitle={textureFileName}>
+    <GuiPanelSection 
+      title={`Textures ${hasLoadedTextureFile ? ` (${textureDefs.length})` : ''}`} 
+      subtitle={textureFileName}
+    >
       <Styled className='textures'>
         {textures}
         {!offsceneTextures.length ? undefined : (

--- a/src/components/panel/GuiPanelTextures.tsx
+++ b/src/components/panel/GuiPanelTextures.tsx
@@ -9,8 +9,10 @@ import {
   selectObjectPolygonIndex,
   selectSceneTextureDefs,
   selectTextureFileName,
+  selectSelectedTexture,
   useAppDispatch,
-  useAppSelector
+  useAppSelector,
+  selectContentViewMode
 } from '@/store';
 import GuiPanelButton from './GuiPanelButton';
 import GuiPanelTexture from './textures/GuiPanelTexture';
@@ -37,25 +39,22 @@ export default function GuiPanelViewOptions() {
   const canExportTextures = useAppSelector(selectCanExportTextures);
   const textureDefs = useAppSelector(selectSceneTextureDefs);
   const textureFileName = useAppSelector(selectTextureFileName);
+  const selectedTexture = useAppSelector(selectSelectedTexture);
+  const contentViewMode = useAppSelector(selectContentViewMode);
   const models = useAppSelector(selectModels);
-
-  const selectedMeshTexture: number = useMemo(() => {
-    const textureIndex = model?.meshes?.[meshIndex]?.textureIndex;
-    return typeof textureIndex === 'number' ? textureIndex : -1;
-  }, [model?.meshes?.[meshIndex]?.textureIndex]);
 
   const polygonIndex = useAppSelector(selectObjectPolygonIndex);
 
   // when selecting a texture, scroll to the item
   useEffect(() => {
     const textureEl = document.getElementById(
-      `gui-panel-t-${selectedMeshTexture}`
+      `gui-panel-t-${selectedTexture}`
     );
 
     if (textureEl) {
       textureEl.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [textureDefs && selectedMeshTexture]);
+  }, [textureDefs && selectedTexture]);
 
   const onExportTextureFile = useCallback(() => {
     dispatch(downloadTextureFile());
@@ -83,7 +82,8 @@ export default function GuiPanelViewOptions() {
               textureDef={textureDef}
               textureIndex={m.textureIndex}
               polygonIndex={polygonIndex}
-              selected={selectedMeshTexture === m.textureIndex}
+              selected={selectedTexture === m.textureIndex}
+              contentViewMode={contentViewMode}
             />
           );
         }
@@ -102,14 +102,15 @@ export default function GuiPanelViewOptions() {
             textureDef={textureDef}
             textureIndex={i}
             polygonIndex={polygonIndex}
-            selected={false}
+            selected={i === selectedTexture}
+            contentViewMode={contentViewMode}
           />
         );
       }
     }
 
     return [pTextures, opTextures];
-  }, [model, meshIndex, textureDefs, selectedMeshTexture, polygonIndex]);
+  }, [model, meshIndex, textureDefs, selectedTexture, polygonIndex, contentViewMode]);
 
   return (
     <GuiPanelSection title='Textures' subtitle={textureFileName}>

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -10,6 +10,7 @@ import { SourceTextureData } from '@/utils/textures/SourceTextureData';
 import { selectReplacementTexture } from '@/store/replaceTextureSlice';
 import uvToCssPathPoint from '@/utils/textures/uvToCssPathPoint';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
+import ContentViewMode from '@/types/ContentViewMode';
 
 const IMG_SIZE = '174px';
 
@@ -67,7 +68,7 @@ const StyledPanelTexture = styled('div')(
     pointer-events: none;
   }
 
-  &.uvs-enabled .selected .img {
+  &.uvs-enabled .selected.mode-polygons .img {
     filter: saturate(0);
     opacity: 0.25;
   }
@@ -109,20 +110,22 @@ export type GuiPanelTextureProps = {
   textureDef: NLTextureDef;
   textureIndex: number;
   polygonIndex: number;
+  contentViewMode: ContentViewMode;
 };
 
 export default function GuiPanelTexture({
   selected,
   textureIndex,
   textureDef,
-  polygonIndex
+  polygonIndex,
+  contentViewMode
 }: GuiPanelTextureProps) {
   const dispatch = useAppDispatch();
   const mesh = useAppSelector(selectMesh);
   const viewOptions = useContext(ViewOptionsContext);
 
   const uvClipPaths = useMemo<string[]>(() => {
-    if (!(selected && mesh?.polygons.length)) {
+    if (!(selected && mesh?.polygons.length) || contentViewMode !== 'polygons') {
       return [];
     }
 
@@ -146,7 +149,7 @@ export default function GuiPanelTexture({
     });
 
     return paths;
-  }, [selected && mesh?.polygons, polygonIndex]);
+  }, [selected && mesh?.polygons, polygonIndex, contentViewMode !== 'polygons']);
 
   const onSelectNewImageFile = useCallback(
     async (imageFile: File) => {
@@ -216,6 +219,7 @@ export default function GuiPanelTexture({
         className={clsx(
           'image-area',
           selected && 'selected',
+          `mode-${contentViewMode}`,
           isDragActive && 'file-drag-active',
           viewOptions.uvRegionsHighlighted
         )}

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -125,7 +125,10 @@ export default function GuiPanelTexture({
   const viewOptions = useContext(ViewOptionsContext);
 
   const uvClipPaths = useMemo<string[]>(() => {
-    if (!(selected && mesh?.polygons.length) || contentViewMode !== 'polygons') {
+    if (
+      !(selected && mesh?.polygons.length) ||
+      contentViewMode !== 'polygons'
+    ) {
       return [];
     }
 
@@ -149,7 +152,11 @@ export default function GuiPanelTexture({
     });
 
     return paths;
-  }, [selected && mesh?.polygons, polygonIndex, contentViewMode !== 'polygons']);
+  }, [
+    selected && mesh?.polygons,
+    polygonIndex,
+    contentViewMode !== 'polygons'
+  ]);
 
   const onSelectNewImageFile = useCallback(
     async (imageFile: File) => {

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -2,10 +2,21 @@ import { useCallback, useContext, useMemo } from 'react';
 import { useDropzone } from 'react-dropzone';
 import clsx from 'clsx';
 import Img from 'next/image';
-import { Skeleton, styled, Typography } from '@mui/material';
+import {
+  ButtonBase,
+  Skeleton,
+  styled,
+  Tooltip,
+  Typography
+} from '@mui/material';
 import { NLTextureDef } from '@/types/NLAbstractions';
 import GuiPanelTextureMenu from './GuiPanelTextureMenu';
-import { selectMesh, useAppDispatch, useAppSelector } from '@/store';
+import {
+  selectMesh,
+  setObjectViewedIndex,
+  useAppDispatch,
+  useAppSelector
+} from '@/store';
 import { SourceTextureData } from '@/utils/textures/SourceTextureData';
 import { selectReplacementTexture } from '@/store/replaceTextureSlice';
 import uvToCssPathPoint from '@/utils/textures/uvToCssPathPoint';
@@ -68,9 +79,13 @@ const StyledPanelTexture = styled('div')(
     pointer-events: none;
   }
 
-  &.uvs-enabled .selected.mode-polygons .img {
+  &.uvs-enabled.mode-polygons .selected .img {
     filter: saturate(0);
     opacity: 0.25;
+  }
+
+  &.mode-textures {
+    cursor: pointer;
   }
 
   .uv-overlay {
@@ -217,48 +232,81 @@ export default function GuiPanelTexture({
     [uvClipPaths, imageDataUrl, width, height, viewOptions.uvRegionsHighlighted]
   );
 
+  const isSelectable = contentViewMode === 'textures' && !selected;
+
+  const mainContentProps = useMemo(
+    () => ({
+      id: `gui-panel-t-${textureIndex}`,
+      className: clsx(
+        'image-area',
+        selected && 'selected',
+        isDragActive && 'file-drag-active',
+        viewOptions.uvRegionsHighlighted
+      ),
+      ...getDragProps(),
+      ...(!isSelectable
+        ? {}
+        : {
+            onClick: () => dispatch(setObjectViewedIndex(textureIndex)),
+            tabIndex: 0,
+            title: 'select this texture'
+          })
+    }),
+    [
+      isDragActive,
+      viewOptions.uvRegionsHighlighted,
+      selected,
+      textureIndex,
+      isSelectable,
+      dispatch
+    ]
+  );
+
+  const content = (
+    <>
+      {!imageDataUrl ? (
+        <Skeleton variant='rectangular' height={170} width='100%' />
+      ) : (
+        <Img
+          src={imageDataUrl}
+          width={width}
+          height={height}
+          alt={`Texture # ${textureIndex}`}
+          className='img'
+        />
+      )}
+      {uvOverlays}
+      <Typography
+        variant='subtitle2'
+        textAlign='right'
+        className='size-notation'
+      >
+        {textureDef.width}x{textureDef.height} [{textureIndex}]
+      </Typography>
+      <GuiPanelTextureMenu
+        textureIndex={textureIndex}
+        width={textureDef.width}
+        height={textureDef.height}
+        pixelsObjectUrls={textureDef.bufferUrls as SourceTextureData}
+        onReplaceImageFile={onSelectNewImageFile}
+      />
+    </>
+  );
+
   return (
     <StyledPanelTexture
-      className={clsx(viewOptions.uvRegionsHighlighted && 'uvs-enabled')}
+      className={clsx(
+        `mode-${contentViewMode}`,
+        viewOptions.uvRegionsHighlighted && 'uvs-enabled'
+      )}
     >
-      <div
-        id={`gui-panel-t-${textureIndex}`}
-        className={clsx(
-          'image-area',
-          selected && 'selected',
-          `mode-${contentViewMode}`,
-          isDragActive && 'file-drag-active',
-          viewOptions.uvRegionsHighlighted
-        )}
-        {...getDragProps()}
-      >
-        {!imageDataUrl ? (
-          <Skeleton variant='rectangular' height={170} width='100%' />
-        ) : (
-          <Img
-            src={imageDataUrl}
-            width={width}
-            height={height}
-            alt={`Texture # ${textureIndex}`}
-            className='img'
-          />
-        )}
-        {uvOverlays}
-        <Typography
-          variant='subtitle2'
-          textAlign='right'
-          className='size-notation'
-        >
-          {textureDef.width}x{textureDef.height} [{textureIndex}]
-        </Typography>
-        <GuiPanelTextureMenu
-          textureIndex={textureIndex}
-          width={textureDef.width}
-          height={textureDef.height}
-          pixelsObjectUrls={textureDef.bufferUrls as SourceTextureData}
-          onReplaceImageFile={onSelectNewImageFile}
-        />
-      </div>
+      {!isSelectable ? (
+        <div {...mainContentProps}>{content}</div>
+      ) : (
+        <Tooltip title='Select this texture'>
+          <ButtonBase {...mainContentProps}>{content}</ButtonBase>
+        </Tooltip>
+      )}
     </StyledPanelTexture>
   );
 }

--- a/src/contexts/SceneContext.tsx
+++ b/src/contexts/SceneContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useState
 } from 'react';
-import { SRGBColorSpace, Scene } from 'three';
+import { Scene, SRGBColorSpace } from 'three';
 
 type SceneContextOptions = {
   scene: Scene | undefined;
@@ -32,9 +32,9 @@ export function SceneContextSetup() {
   useEffect(() => {
     setScene(scene);
   }, [scene]);
-  
+
   useEffect(() => {
-    if(gl) {
+    if (gl) {
       gl.outputColorSpace = SRGBColorSpace;
     }
   }, [gl]);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,4 @@
-export { default as useSceneKeyboardControls } from './useSceneKeyboardControls';
+export { default as useObjectNavControls } from './useObjectNavControls';
 export { default as useModelSelectionExport } from './useModelSelectionExport';
 export { default as useHeldRepetitionTimer } from './useHeldRepetitionTimer';
 export { default as useDebouncedEffect } from './useDebouncedEffect';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,7 @@
 export { default as useObjectNavControls } from './useObjectNavControls';
 export { default as useModelSelectionExport } from './useModelSelectionExport';
+export { default as useObjectUINav } from './useObjectUINav';
 export { default as useHeldRepetitionTimer } from './useHeldRepetitionTimer';
 export { default as useDebouncedEffect } from './useDebouncedEffect';
+export { default as useSceneGLTFFileDownloader } from './useSceneGLTFFileDownloader';
+export { default as useSupportedFilePicker } from './useSupportedFilePicker';

--- a/src/hooks/useModelSelectionExport.ts
+++ b/src/hooks/useModelSelectionExport.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from 'react';
 import exportFromJSON from 'export-from-json';
 import {
+  selectMeshSelectionType,
   selectModel,
   selectModelIndex,
   selectObjectKey,
-  selectMeshSelectionType,
   useAppSelector
 } from '@/store';
 

--- a/src/hooks/useObjectNavControls.ts
+++ b/src/hooks/useObjectNavControls.ts
@@ -6,7 +6,8 @@ import { AnyAction } from '@reduxjs/toolkit';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import useHeldRepetitionTimer from './useHeldRepetitionTimer';
 
-export default function useSceneKeyboardControls() {
+/** controls left/right object nav as well as hides and shows the gui menu */
+export default function useObjectNavControls() {
   const dispatch = useDispatch();
   const viewOptions = useContext(ViewOptionsContext);
   const isLeftPressed = useKeyPress({ targetKey: 'ArrowLeft' });
@@ -14,26 +15,26 @@ export default function useSceneKeyboardControls() {
   const isControlPressed = useKeyPress({ targetKey: 'Control' });
   const isSlashPressed = useKeyPress({ targetKey: '\\' });
 
-  const [onStartPrevModelNav, onStopPrevModelNav] = useHeldRepetitionTimer();
-  const [onStartNextModelNav, onStopNextModelNav] = useHeldRepetitionTimer();
+  const [onStartPrevObjectNav, onStopPrevObjectNav] = useHeldRepetitionTimer();
+  const [onStartNextObjectNav, onStopNextObjectNav] = useHeldRepetitionTimer();
 
   useEffect(() => {
     if (isLeftPressed) {
-      onStartPrevModelNav(() => {
+      onStartPrevObjectNav(() => {
         dispatch(navToPrevObject() as unknown as AnyAction);
       });
     } else {
-      onStopPrevModelNav();
+      onStopPrevObjectNav();
     }
   }, [isLeftPressed]);
 
   useEffect(() => {
     if (isRightPressed) {
-      onStartNextModelNav(() => {
+      onStartNextObjectNav(() => {
         dispatch(navToNextObject() as unknown as AnyAction);
       });
     } else {
-      onStopNextModelNav();
+      onStopNextObjectNav();
     }
   }, [isRightPressed]);
 

--- a/src/hooks/useObjectUINav.ts
+++ b/src/hooks/useObjectUINav.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import useHeldRepetitionTimer from './useHeldRepetitionTimer';
+import {
+  navToNextObject,
+  navToPrevObject,
+  selectObjectCount,
+  selectObjectIndex,
+  useAppDispatch,
+  useAppSelector
+} from '@/store';
+
+export default function useObjectNavUIControls() {
+  const dispatch = useAppDispatch();
+  const objectIndex = useAppSelector(selectObjectIndex);
+  const objectCount = useAppSelector(selectObjectCount);
+
+  const [onStartPrevObjectNav, onStopPrevObjectNav] = useHeldRepetitionTimer();
+  const [onStartNextObjectNav, onStopNextObjectNav] = useHeldRepetitionTimer();
+
+  useEffect(() => {
+    window.addEventListener('mouseup', onStopPrevObjectNav);
+    window.addEventListener('mouseup', onStopNextObjectNav);
+    return () => {
+      window.removeEventListener('mouseup', onStopPrevObjectNav);
+      window.removeEventListener('mouseup', onStopNextObjectNav);
+    };
+  }, []);
+
+  const onStartPrevObjectClick = useCallback(() => {
+    onStartPrevObjectNav(() => {
+      dispatch(navToPrevObject());
+    });
+  }, [objectIndex]);
+
+  const onStartNextObjectClick = useCallback(() => {
+    onStartNextObjectNav(() => {
+      dispatch(navToNextObject());
+    });
+  }, [objectIndex]);
+
+  const prevButtonProps = useMemo(
+    () => ({
+      onMouseDown: onStartPrevObjectClick,
+      onMouseUp: onStopPrevObjectNav,
+      disabled: objectIndex === 0
+    }),
+    [onStartPrevObjectClick, onStopPrevObjectNav, objectIndex]
+  );
+
+  const nextButtonProps = useMemo(
+    () => ({
+      onMouseDown: onStartNextObjectClick,
+      onMouseUp: onStopNextObjectNav,
+      disabled: objectIndex === objectCount - 1
+    }),
+    [onStartNextObjectClick, onStopNextObjectNav, objectIndex, objectCount]
+  );
+
+  const returnValue = useMemo(
+    () => ({
+      prevButtonProps,
+      nextButtonProps
+    }),
+    [prevButtonProps, nextButtonProps]
+  );
+
+  return returnValue;
+}

--- a/src/hooks/useSceneGLTFFileDownloader.ts
+++ b/src/hooks/useSceneGLTFFileDownloader.ts
@@ -9,8 +9,8 @@ async function rotateDataUri(dataURI: string): Promise<string> {
     img.src = dataURI;
 
     img.onload = () => {
-      const canvas = document.createElement("canvas");
-      const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
 
       const width = img.height;
       const height = img.width;
@@ -49,17 +49,21 @@ export default function useSceneGLTFFileDownloader() {
       throw new Error('no scene instantiated to get GLTF file');
     }
 
-    const output = await exporter.parseAsync(scene) as { images: GLTFImage[] };
+    const output = (await exporter.parseAsync(scene)) as {
+      images: GLTFImage[];
+    };
 
     const rotationPromises = output.images.map(async (img) => {
       const uri = await rotateDataUri(img.uri);
       return { ...img, uri };
     });
-    
-    const rotatedImages = await Promise.all(rotationPromises);    
+
+    const rotatedImages = await Promise.all(rotationPromises);
     output.images = rotatedImages;
-   
-    const file = new Blob([JSON.stringify(output, null, 2)], { type: 'application/object' });
+
+    const file = new Blob([JSON.stringify(output, null, 2)], {
+      type: 'application/object'
+    });
     const link = document.createElement('a');
     link.href = window.URL.createObjectURL(file);
     const name = polygonFileName.substring(0, polygonFileName.lastIndexOf('.'));

--- a/src/hooks/useSupportedFilePicker.ts
+++ b/src/hooks/useSupportedFilePicker.ts
@@ -84,7 +84,9 @@ export const handleFileInput = async (
   });
 
   if (!selectedPolygonFile && !selectedTextureFile) {
-    handleError('Invalid file selected. See "What Files Can I Use" for more info.');
+    handleError(
+      'Invalid file selected. See "What Files Can I Use" for more info.'
+    );
     return;
   }
 
@@ -97,8 +99,8 @@ export const handleFileInput = async (
       dispatch(loadTextureFile({ file: selectedTextureFile, textureFileType }));
     } else {
       handleError(
-        'For this type of texture file, you must load a polygon file along with it. ' + 
-        'You can hold control in most file selectors to select most files'
+        'For this type of texture file, you must load a polygon file along with it. ' +
+          'You can hold control in most file selectors to select most files'
       );
       return;
     }

--- a/src/store/objectViewerSlice.ts
+++ b/src/store/objectViewerSlice.ts
@@ -22,22 +22,10 @@ export const initialObjectViewerState: ObjectViewerState = {
 
 const sliceName = 'objectViewer';
 
-export const navToNextObject = createAsyncThunk<
-  void,
-  undefined,
-  { state: AppState }
->(`${sliceName}/navToNextObject`, async (_, { dispatch, getState }) => {
-  const state = getState();
-  const objectCount = state.modelData.models.length;
-  const objectIndex = Math.min(state.objectViewer.modelIndex + 1, objectCount - 1);
-
-  dispatch(setObjectViewedIndex(objectIndex));
-});
-
 export const setObjectViewedIndex = createAsyncThunk<
 { objectIndex: number, indexKey: 'modelIndex' | 'textureIndex' },
-  number,
-  { state: AppState }
+number,
+{ state: AppState }
 >(`${sliceName}/setObjectViewedIndex`, async (objectIndex, { getState }) => {
   const state = getState();
   const contentViewMode = selectContentViewMode(state);
@@ -46,15 +34,30 @@ export const setObjectViewedIndex = createAsyncThunk<
 });
 
 export const navToPrevObject = createAsyncThunk<
-  void,
-  undefined,
-  { state: AppState }
+void,
+undefined,
+{ state: AppState }
 >(`${sliceName}/navToPrevObject`, async (_, { dispatch, getState }) => {
   const state = getState();
   const contentViewMode = selectContentViewMode(state);
   const indexKey = contentViewMode === 'polygons' ? 'modelIndex' : 'textureIndex';
   let index = state.objectViewer[indexKey];
   const objectIndex = Math.max(index - 1, 0);
+  
+  dispatch(setObjectViewedIndex(objectIndex));
+});
+
+export const navToNextObject = createAsyncThunk<
+  void,
+  undefined,
+  { state: AppState }
+>(`${sliceName}/navToNextObject`, async (_, { dispatch, getState }) => {
+  const state = getState();
+  const contentViewMode = selectContentViewMode(state);
+  const indexKey = contentViewMode === 'polygons' ? 'modelIndex' : 'textureIndex';
+  const objectsKey = contentViewMode === 'polygons' ? 'models' : 'textureDefs';
+  const objectCount = state.modelData[objectsKey].length;
+  const objectIndex = Math.min(state.objectViewer[indexKey] + 1, objectCount - 1);
 
   dispatch(setObjectViewedIndex(objectIndex));
 });

--- a/src/store/objectViewerSlice.ts
+++ b/src/store/objectViewerSlice.ts
@@ -23,27 +23,29 @@ export const initialObjectViewerState: ObjectViewerState = {
 const sliceName = 'objectViewer';
 
 export const setObjectViewedIndex = createAsyncThunk<
-{ objectIndex: number, indexKey: 'modelIndex' | 'textureIndex' },
-number,
-{ state: AppState }
+  { objectIndex: number; indexKey: 'modelIndex' | 'textureIndex' },
+  number,
+  { state: AppState }
 >(`${sliceName}/setObjectViewedIndex`, async (objectIndex, { getState }) => {
   const state = getState();
   const contentViewMode = selectContentViewMode(state);
-  const indexKey = contentViewMode === 'polygons' ? 'modelIndex' : 'textureIndex';
+  const indexKey =
+    contentViewMode === 'polygons' ? 'modelIndex' : 'textureIndex';
   return { objectIndex, indexKey };
 });
 
 export const navToPrevObject = createAsyncThunk<
-void,
-undefined,
-{ state: AppState }
+  void,
+  undefined,
+  { state: AppState }
 >(`${sliceName}/navToPrevObject`, async (_, { dispatch, getState }) => {
   const state = getState();
   const contentViewMode = selectContentViewMode(state);
-  const indexKey = contentViewMode === 'polygons' ? 'modelIndex' : 'textureIndex';
-  let index = state.objectViewer[indexKey];
+  const indexKey =
+    contentViewMode === 'polygons' ? 'modelIndex' : 'textureIndex';
+  const index = state.objectViewer[indexKey];
   const objectIndex = Math.max(index - 1, 0);
-  
+
   dispatch(setObjectViewedIndex(objectIndex));
 });
 
@@ -54,10 +56,14 @@ export const navToNextObject = createAsyncThunk<
 >(`${sliceName}/navToNextObject`, async (_, { dispatch, getState }) => {
   const state = getState();
   const contentViewMode = selectContentViewMode(state);
-  const indexKey = contentViewMode === 'polygons' ? 'modelIndex' : 'textureIndex';
+  const indexKey =
+    contentViewMode === 'polygons' ? 'modelIndex' : 'textureIndex';
   const objectsKey = contentViewMode === 'polygons' ? 'models' : 'textureDefs';
   const objectCount = state.modelData[objectsKey].length;
-  const objectIndex = Math.min(state.objectViewer[indexKey] + 1, objectCount - 1);
+  const objectIndex = Math.min(
+    state.objectViewer[indexKey] + 1,
+    objectCount - 1
+  );
 
   dispatch(setObjectViewedIndex(objectIndex));
 });
@@ -89,12 +95,15 @@ const objectViewerSlice = createSlice({
       });
     });
 
-    builder.addCase(setObjectViewedIndex.fulfilled, (state, { payload: { objectIndex, indexKey } }) => {
-      Object.assign(state, {
-        [indexKey]: objectIndex,
-        objectKey: undefined
-      });
-    });
+    builder.addCase(
+      setObjectViewedIndex.fulfilled,
+      (state, { payload: { objectIndex, indexKey } }) => {
+        Object.assign(state, {
+          [indexKey]: objectIndex,
+          objectKey: undefined
+        });
+      }
+    );
   }
 });
 

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { AppState } from './store';
+import ContentViewMode from '../types/ContentViewMode';
 
 export const selectModelIndex = (s: AppState) => s.objectViewer.modelIndex;
 
@@ -12,12 +13,6 @@ export const selectHasLoadedPolygonFile = (s: AppState) =>
 
 export const selectHasLoadedTextureFile = (s: AppState) =>
   Boolean(s.modelData.textureFileName);
-
-export const selectHasLoadedFile = createSelector(
-  selectHasLoadedPolygonFile,
-  selectHasLoadedTextureFile,
-  (m, p) => m || p
-);
 
 export const selectHasEditedTextures = (s: AppState) =>
   s.modelData.hasEditedTextures;
@@ -170,3 +165,16 @@ export const selectCanExportTextures = createSelector(
 
 export const selectTextureFileType = (s: AppState) => s.modelData.textureFileType;
 export const selectHasCompressedTextures = (s: AppState) => s.modelData.hasCompressedTextures;
+
+export const selectContentViewMode = createSelector(
+  selectHasLoadedTextureFile, selectHasLoadedPolygonFile,
+  (hasLoadedTextures, hasLoadedPolygons): ContentViewMode =>{
+    if(hasLoadedTextures && !hasLoadedPolygons) {
+      return 'textures';
+    } else if(hasLoadedPolygons) {
+      return 'polygons';
+    } else {
+      return 'welcome';
+    }
+  }
+);

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -173,3 +173,25 @@ export const selectContentViewMode = createSelector(
     }
   }
 );
+
+export const selectSelectedTexture = createSelector(
+  selectContentViewMode,
+  selectModel,
+  selectObjectMeshIndex,
+  selectTextureIndex,
+  (contentViewMode, model, meshIndex, textureIndex) => {
+    switch(contentViewMode) {
+      case 'textures': {
+        return textureIndex;
+      }
+      case 'polygons': {
+        const textureIndex = model?.meshes?.[meshIndex]?.textureIndex;
+        return typeof textureIndex === 'number' ? textureIndex : -1
+      }
+      default:
+      case 'welcome': {
+        return -1;
+      }
+    }
+  }
+);

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -154,19 +154,21 @@ export const selectIsFileSupportDialogShown = (s: AppState) =>
 
 export const selectCanExportTextures = createSelector(
   selectTextureFileName,
-  (textureFileName) =>
-    Boolean(textureFileName)
+  (textureFileName) => Boolean(textureFileName)
 );
 
-export const selectTextureFileType = (s: AppState) => s.modelData.textureFileType;
-export const selectHasCompressedTextures = (s: AppState) => s.modelData.hasCompressedTextures;
+export const selectTextureFileType = (s: AppState) =>
+  s.modelData.textureFileType;
+export const selectHasCompressedTextures = (s: AppState) =>
+  s.modelData.hasCompressedTextures;
 
 export const selectContentViewMode = createSelector(
-  selectHasLoadedTextureFile, selectHasLoadedPolygonFile,
-  (hasLoadedTextures, hasLoadedPolygons): ContentViewMode =>{
-    if(hasLoadedTextures && !hasLoadedPolygons) {
+  selectHasLoadedTextureFile,
+  selectHasLoadedPolygonFile,
+  (hasLoadedTextures, hasLoadedPolygons): ContentViewMode => {
+    if (hasLoadedTextures && !hasLoadedPolygons) {
       return 'textures';
-    } else if(hasLoadedPolygons) {
+    } else if (hasLoadedPolygons) {
       return 'polygons';
     } else {
       return 'welcome';
@@ -180,18 +182,50 @@ export const selectSelectedTexture = createSelector(
   selectObjectMeshIndex,
   selectTextureIndex,
   (contentViewMode, model, meshIndex, textureIndex) => {
-    switch(contentViewMode) {
+    switch (contentViewMode) {
       case 'textures': {
         return textureIndex;
       }
       case 'polygons': {
         const textureIndex = model?.meshes?.[meshIndex]?.textureIndex;
-        return typeof textureIndex === 'number' ? textureIndex : -1
+        return typeof textureIndex === 'number' ? textureIndex : -1;
       }
       default:
       case 'welcome': {
         return -1;
       }
+    }
+  }
+);
+
+export const selectObjectIndex = createSelector(
+  selectContentViewMode,
+  selectModelIndex,
+  selectTextureIndex,
+  (viewMode, modelIndex, textureIndex) => {
+    switch (viewMode) {
+      case 'polygons':
+        return modelIndex;
+      case 'textures':
+        return textureIndex;
+      default:
+        return -1;
+    }
+  }
+);
+
+export const selectObjectCount = createSelector(
+  selectContentViewMode,
+  selectModels,
+  selectTextureDefs,
+  (viewMode, models, textureDefs) => {
+    switch (viewMode) {
+      case 'polygons':
+        return models.length;
+      case 'textures':
+        return textureDefs.length;
+      default:
+        return 0;
     }
   }
 );

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -3,30 +3,25 @@ import { AppState } from './store';
 import ContentViewMode from '../types/ContentViewMode';
 
 export const selectModelIndex = (s: AppState) => s.objectViewer.modelIndex;
-
+export const selectTextureIndex = (s: AppState) => s.objectViewer.textureIndex;
 export const selectObjectKey = (s: AppState) => s.objectViewer.objectKey;
-
 export const selectModels = (s: AppState) => s.modelData.models;
-
 export const selectHasLoadedPolygonFile = (s: AppState) =>
   Boolean(s.modelData.polygonFileName);
-
 export const selectHasLoadedTextureFile = (s: AppState) =>
   Boolean(s.modelData.textureFileName);
-
 export const selectHasEditedTextures = (s: AppState) =>
   s.modelData.hasEditedTextures;
-
 export const selectModelCount = createSelector(
   selectModels,
   (models) => models.length
 );
 export const selectMeshSelectionType = (s: AppState) =>
   s.objectViewer.meshSelectionType;
-
 export const selectTextureDefs = (s: AppState) => s.modelData.textureDefs;
 export const selectTextureBufferUrlHistory = (s: AppState) =>
   s.modelData.textureHistory;
+
 /**
  * get a set of base texture urls to detect presence in O(1)
  */

--- a/src/theming/themes.ts
+++ b/src/theming/themes.ts
@@ -23,14 +23,14 @@ declare module '@mui/material' {
   }
 
   interface PaletteOptions {
-    warningBackground: CSSProperties['color']
+    warningBackground: CSSProperties['color'];
     scene: ScenePalette;
     panelTexture: PanelTexturePalette;
   }
 
   // note: redundancy is due to MUI typings
   interface Palette {
-    warningBackground: CSSProperties['color']
+    warningBackground: CSSProperties['color'];
     scene: ScenePalette;
     panelTexture: PanelTexturePalette;
   }

--- a/src/types/ContentViewMode.ts
+++ b/src/types/ContentViewMode.ts
@@ -1,0 +1,3 @@
+type ContentViewMode = 'textures' | 'polygons' | 'welcome';
+
+export default ContentViewMode;

--- a/src/utils/textures/files/textureFileTypeMap.ts
+++ b/src/utils/textures/files/textureFileTypeMap.ts
@@ -9,12 +9,12 @@ export type TextureFileType =
 export const CHARACTER_PORTRAITS = /^PL[0-9A-Z]{2}_FAC(.mn)?.BIN$/i;
 export const MVC2_CHARACTER_WIN = /^PL[0-9A-Z]{2}_WIN(.mn)?.BIN$/i;
 export const POLYGON_MAPPED_TEXTURE =
-/^(((((STG(E)?|DM)[0-9A-Z]{2})|EFKY))|(DC[0-9A-Z]{2}(E)?))TEX(.mn)?.BIN$/
+  /^(((((STG(E)?|DM)[0-9A-Z]{2})|EFKY))|(DC[0-9A-Z]{2}(E)?))TEX(.mn)?.BIN$/;
 export const MVC2_STAGE_PREVIEWS = /^SELSTG(.mn)?.BIN$/i;
 export const MVC2_SELECTION_TEXTURES = /^SELTEX(.mn)?.BIN$/i;
 export const MVC2_END_ART = /^END(DC|NM)TEX(.mn)?.BIN$/i;
 
-/** 
+/**
  * @TODO: provide more granularity for every type of texture
  * in terms of polygon-mapped variants, and infer polygon-mapped
  * mode from subgroup of variants

--- a/src/utils/textures/parse/compressTextureBuffer.ts
+++ b/src/utils/textures/parse/compressTextureBuffer.ts
@@ -41,7 +41,7 @@ export default function compressTextureBuffer(buffer: Buffer) {
     }
 
     const occurenceList = wordOccurences.get(word) as LinkedList<number>;
-    
+
     occurenceList.append(i);
     // clean up occurences not within targeted range
     while (
@@ -62,13 +62,13 @@ export default function compressTextureBuffer(buffer: Buffer) {
     let sequenceIndex = -1;
 
     while (sequenceNode) {
-      const wordsBackCount = i - sequenceNode!.data;
+      const wordsBackCount = i - sequenceNode?.data;
       let length = 1;
 
       // for each starting word, travel through to see
       // if there is a matching sequence
-      
-      if(sequenceNode.data < i) {
+
+      if (sequenceNode.data < i) {
         let hasMatch = true;
         while (
           hasMatch &&
@@ -77,13 +77,14 @@ export default function compressTextureBuffer(buffer: Buffer) {
           length + 1 < W16_MAX_LOOKBACK &&
           // 32 bit words must have wordsBackCount satisfying
           // criteria of being at least 2047
-          ((wordsBackCount < W16_MAX_LOOKBACK && length < 31) || (wordsBackCount >= W16_MAX_LOOKBACK))
+          ((wordsBackCount < W16_MAX_LOOKBACK && length < 31) ||
+            wordsBackCount >= W16_MAX_LOOKBACK)
         ) {
           const sI = (sequenceNode.data + length) * WORD_SIZE;
           const nI = (i + length) * WORD_SIZE;
           const sequenceWord = buffer[sI] | (buffer[sI + 1] << 8);
           const nextWord = buffer[nI] | (buffer[nI + 1] << 8);
-          
+
           if (nextWord === sequenceWord) {
             length++;
           } else {
@@ -161,11 +162,11 @@ export default function compressTextureBuffer(buffer: Buffer) {
 
   outputBuffer = outputBuffer.subarray(0, byteOffset + 2 * escapeWordCount);
 
-  while(escapeWordCount) {
+  while (escapeWordCount) {
     outputBuffer.writeUInt16LE(0, byteOffset);
     byteOffset += 2;
     escapeWordCount--;
-  } 
+  }
 
   console.timeEnd('compressTextureBuffer');
   return outputBuffer;

--- a/src/utils/textures/parse/decompressTextureBuffer.ts
+++ b/src/utils/textures/parse/decompressTextureBuffer.ts
@@ -43,7 +43,7 @@ export default function decompressTextureBuffer(bufferPassed: Buffer) {
         wordsBackCount = word & BITS11;
       } else {
         wordsBackCount = word;
-        
+
         // advance/read an extra 2 bytes
         grabWordCount = buffer.readUInt16LE(++i * WORD_SIZE);
       }


### PR DESCRIPTION
First iteration of dedicated texture view sans controls below textures. Allows for selection UX via textures to see full-screen previews on the unused window space and has different content view modes + associated refactors.

Partially addresses #123 
![image](https://github.com/rob2d/modnao/assets/1799905/3ddfd157-656e-4c9e-ab7a-dc94204474d7)
