### PR TITLE
refactor compression-related files & clean-up

### DIFF
--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -1,6 +1,6 @@
+import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { useDropzone } from 'react-dropzone';
-import clsx from 'clsx';
 import Img from 'next/image';
 import {
   ButtonBase,
@@ -17,9 +17,8 @@ import {
   useAppDispatch,
   useAppSelector
 } from '@/store';
-import { SourceTextureData } from '@/utils/textures/SourceTextureData';
+import { SourceTextureData, uvToCssPathPoint } from '@/utils/textures';
 import { selectReplacementTexture } from '@/store/replaceTextureSlice';
-import uvToCssPathPoint from '@/utils/textures/uvToCssPathPoint';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import ContentViewMode from '@/types/ContentViewMode';
 

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -17,9 +17,9 @@ import {
 } from './selectors';
 import { SourceTextureData } from '@/utils/textures/SourceTextureData';
 import WorkerThreadPool from '../utils/WorkerThreadPool';
-import { decompressTextureBuffer } from '@/utils/textures/parse';
 import { batch } from 'react-redux';
 import { TextureFileType } from '@/utils/textures/files/textureFileTypeMap';
+import { decompressLzssBuffer } from '@/utils/data';
 
 const workerPool = new WorkerThreadPool();
 
@@ -132,14 +132,14 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
 
   const uint8Array = new Uint8Array(arrayBuffer);
   const compressedJpLifebarAssets = uint8Array.slice(pointers[0], pointers[1]);
-  const jpLifebar = await decompressTextureBuffer(
+  const jpLifebar = await decompressLzssBuffer(
     Buffer.from(compressedJpLifebarAssets)
   );
   let usLifebar: Uint8Array | undefined;
 
   if (pointers[3]) {
     const compressedUsLifebarAssets = uint8Array.slice(pointers[3]);
-    usLifebar = await decompressTextureBuffer(
+    usLifebar = await decompressLzssBuffer(
       Buffer.from(compressedUsLifebarAssets)
     );
   }
@@ -276,7 +276,7 @@ const loadCompressedTextureFiles = async (
     return;
   }
   const arrayBuffer = await file.arrayBuffer();
-  const buffer = decompressTextureBuffer(Buffer.from(arrayBuffer));
+  const buffer = decompressLzssBuffer(Buffer.from(arrayBuffer));
 
   const result = await new Promise<LoadTexturesPayload>((resolve) => {
     if (thread) {

--- a/src/utils/data/compressLzssBuffer.ts
+++ b/src/utils/data/compressLzssBuffer.ts
@@ -8,11 +8,9 @@ const COMPRESSION_FLAG = 0b1000_0000_0000_0000;
 /** in 16 bit mode, can look back a max of 11 bits */
 const W16_MAX_LOOKBACK = 0b111_1111_1111;
 
-/**
- * @param buffer decompressed buffer to compress
- */
-export default function compressTextureBuffer(buffer: Buffer) {
-  console.time('compressTextureBuffer');
+/** @param buffer decompressed buffer to compress */
+export default function compressLzssBuffer(buffer: Buffer) {
+  console.time('compressLzssBuffer');
   let i = 0;
 
   // create a structure that maps sequences of word ops
@@ -168,6 +166,6 @@ export default function compressTextureBuffer(buffer: Buffer) {
     escapeWordCount--;
   }
 
-  console.timeEnd('compressTextureBuffer');
+  console.timeEnd('compressLzssBuffer');
   return outputBuffer;
 }

--- a/src/utils/data/decompressLzssBuffer.ts
+++ b/src/utils/data/decompressLzssBuffer.ts
@@ -5,7 +5,7 @@ const COMPRESSION_FLAG = 0b1000_0000_0000_0000;
 
 const BITS11 = 0b111_1111_1111;
 
-export default function decompressTextureBuffer(bufferPassed: Buffer) {
+export default function decompressLzssBuffer(bufferPassed: Buffer) {
   const buffer = Buffer.from(bufferPassed);
   const output: number[] = [];
   let applyBitmask = true;

--- a/src/utils/data/index.ts
+++ b/src/utils/data/index.ts
@@ -1,2 +1,4 @@
 export { default as bufferToObjectUrl } from './bufferToObjectUrl';
 export { default as objectUrlToBuffer } from './objectUrlToBuffer';
+export { default as decompressLzssBuffer } from './decompressLzssBuffer';
+export { default as compressLzssBuffer } from './compressLzssBuffer';

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -1,12 +1,16 @@
 import quanti from 'quanti';
 import { NLTextureDef } from '@/types/NLAbstractions';
-import decodeZMortonPosition from '@/utils/textures/serialize/decodeZMortonPosition';
-import rgbaToRgb565 from '@/utils/color-conversions/rgbaToRgb565';
-import rgbaToArgb1555 from '@/utils/color-conversions/rgbaToArgb1555';
-import rgbaToArgb4444 from '@/utils/color-conversions/rgbaToArgb4444';
-import { RgbaColor, TextureColorFormat } from '@/utils/textures';
-import { compressTextureBuffer } from '@/utils/textures/parse';
-import { objectUrlToBuffer } from '@/utils/data';
+import {
+  rgbaToArgb1555,
+  rgbaToArgb4444,
+  rgbaToRgb565
+} from '@/utils/color-conversions';
+import {
+  decodeZMortonPosition,
+  RgbaColor,
+  TextureColorFormat
+} from '@/utils/textures';
+import { compressLzssBuffer, objectUrlToBuffer } from '@/utils/data';
 import { TextureFileType } from './textureFileTypeMap';
 
 const COLOR_SIZE = 2;
@@ -156,7 +160,7 @@ export default async function exportTextureFile({
       const jpSection = Buffer.from(uint8Array.slice(pointers[0], pointers[1]));
       const compressedJpSection = padBufferForAlignment(
         startPointer,
-        compressTextureBuffer(jpSection)
+        compressLzssBuffer(jpSection)
       );
 
       buffer.writeUInt32LE(startPointer, 0);
@@ -179,7 +183,7 @@ export default async function exportTextureFile({
         );
         compressedUsSection = padBufferForAlignment(
           startPointer,
-          compressTextureBuffer(usSection)
+          compressLzssBuffer(usSection)
         );
         buffer.writeUInt32LE(
           startPointer +
@@ -205,7 +209,7 @@ export default async function exportTextureFile({
     default: {
       const outputBuffer = !isCompressedTexture
         ? textureBuffer
-        : compressTextureBuffer(textureBuffer);
+        : compressLzssBuffer(textureBuffer);
 
       output = new Blob([outputBuffer], {
         type: 'application/octet-stream'

--- a/src/utils/textures/index.ts
+++ b/src/utils/textures/index.ts
@@ -1,3 +1,7 @@
 export * from './RgbaColor';
 export * from './TextureSize';
 export * from './TextureColorFormat';
+export * from './SourceTextureData';
+export { default as uvToCssPathPoint } from './uvToCssPathPoint';
+export * from './serialize';
+export * from './parse';

--- a/src/utils/textures/parse/index.ts
+++ b/src/utils/textures/parse/index.ts
@@ -1,6 +1,5 @@
-export { default as compressTextureBuffer } from './compressTextureBuffer';
-export { default as decompressTextureBuffer } from './decompressTextureBuffer';
 export { default as encodeZMortonPosition } from './encodeZMortonPosition';
 export { default as getTextureColorFormat } from './getTextureColorFormat';
 export { default as getTextureSize } from './getTextureSize';
 export { default as getTextureWrappingFlags } from './getTextureWrappingFlags';
+export { default as loadTextureFile } from './loadTextureFile';

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -1,8 +1,5 @@
 import { Image } from 'image-js';
-import {
-  decompressTextureBuffer,
-  encodeZMortonPosition
-} from '@/utils/textures/parse';
+import { encodeZMortonPosition } from '@/utils/textures/parse';
 import { NLTextureDef, TextureDataUrlType } from '@/types/NLAbstractions';
 import {
   argb1555ToRgba8888,
@@ -10,7 +7,7 @@ import {
   rgb565ToRgba8888
 } from '@/utils/color-conversions';
 import { RgbaColor, TextureColorFormat } from '@/utils/textures';
-import { bufferToObjectUrl } from '@/utils/data';
+import { bufferToObjectUrl, decompressLzssBuffer } from '@/utils/data';
 import { TextureFileType } from '../files/textureFileTypeMap';
 
 const COLOR_SIZE = 2;
@@ -139,7 +136,7 @@ export default async function loadTextureFile({
       throw error;
     }
 
-    const decompressedBuffer = decompressTextureBuffer(buffer);
+    const decompressedBuffer = decompressLzssBuffer(buffer);
 
     const textureBufferData = await loadTextureBuffer(
       decompressedBuffer,

--- a/src/utils/textures/serialize/index.ts
+++ b/src/utils/textures/serialize/index.ts
@@ -1,0 +1,1 @@
+export { default as decodeZMortonPosition } from './decodeZMortonPosition';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,10 +1,10 @@
-import loadTextureFile from './utils/textures/parse/loadTextureFile';
 import { NLTextureDef } from './types/NLAbstractions';
 import HslValues from './utils/textures/HslValues';
 import adjustTextureHsl from './utils/textures/adjustTextureHsl';
 import { SourceTextureData } from './utils/textures/SourceTextureData';
 import TransferrableBuffer from './types/TransferrableBuffer';
 import loadPolygonFile from './utils/polygons/parse/loadPolygonFile';
+import loadTextureFile from './utils/textures/parse/loadTextureFile';
 import { TextureFileType } from './utils/textures/files/textureFileTypeMap';
 
 export type WorkerEvent =


### PR DESCRIPTION
Revisiting outdated code before introducing VQ image compression for #122. There were also a few cases where barrel/esmodules were introduced that weren't yet consumed (exception: not used in workers purposely to minimize the size of worker loaded).