### PR TITLE
support vector quantized images (import and export using ml clustering algo)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,6 +23,11 @@ const customJestConfig = {
     // https://jestjs.io/docs/webpack#mocking-css-modules
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
 
+    // workaround to support non esmodule compiled package:
+    // jest-module name mapping will actually roll up packages
+    // with name transforms, even if they are accessed the same way
+    kmeans: ['<rootDir>/node_modules/@thi.ng/k-means'],
+
     // Handle CSS imports (without CSS modules)
     '^.+\\.(css|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
 
@@ -35,14 +40,16 @@ const customJestConfig = {
   },
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/.next/',
+    '<rootDir>/node_modules/(!(@thi.ng/k-means)/)'
+  ],
   testEnvironment: 'jest-environment-jsdom',
   transform: {
     // Use babel-jest to transpile tests with the next/babel preset
     // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
     '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }]
-  },
-  transformIgnorePatterns: ['/node_modules/', '^.+\\.module\\.(css|sass|scss)$']
+  }
 };
 
 module.exports = async () => ({

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,8 @@ const nextConfig = {
     '@mui/material',
     '@mui/system',
     '@mui/icons-material',
-    'three'
+    'three',
+    '@thi.ng/k-means'
   ],
   modularizeImports: {
     '@mui/icons-material/?(((\\w*)?/?)*)': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
+        "@thi.ng/k-means": "^0.6.36",
         "@types/jimp": "^0.2.28",
         "@types/node": "18.16.1",
         "@types/react": "18.2.0",
@@ -4664,6 +4665,429 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@thi.ng/api": {
+      "version": "8.9.5",
+      "resolved": "https://registry.npmjs.org/@thi.ng/api/-/api-8.9.5.tgz",
+      "integrity": "sha512-8rh1FypiQHzF/pDWqvvlRfRdr78nZe9n3HxbL5Swx9gFDfkU/ZIavW+8uLk8uZFAwnlkMnCOBeVsZEtIsqrVLw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/arrays": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@thi.ng/arrays/-/arrays-2.6.3.tgz",
+      "integrity": "sha512-XzK/Z18vA09vby4ByoFvvewfivDm1GKm4RUC+RTAYnXOhohdh9XGH6aDwUuQQhZ/RAXvTlvAWY1FaWtqXvG9WQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/checks": "^3.4.5",
+        "@thi.ng/compare": "^2.2.0",
+        "@thi.ng/equiv": "^2.1.30",
+        "@thi.ng/errors": "^2.3.5",
+        "@thi.ng/random": "^3.6.8"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/binary": {
+      "version": "3.3.33",
+      "resolved": "https://registry.npmjs.org/@thi.ng/binary/-/binary-3.3.33.tgz",
+      "integrity": "sha512-ZquZDGuXrpa/hO5/X534Su+8dkjpgtS+nJRtmgsa2g288/1CaehsAGSKchCqO0asX9gUxTpbpuIJFPcQoJr6yw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/checks": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@thi.ng/checks/-/checks-3.4.5.tgz",
+      "integrity": "sha512-f187dpm/VjzP3cMK5YhGPlM6zTXvKBu3WKQ9Rvf7uDe1p55FtSI7K4TvCEMxySWRGIzCXvvvQsvkrl7r3eYAqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/compare": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@thi.ng/compare/-/compare-2.2.0.tgz",
+      "integrity": "sha512-/zpeN6EBH8uFvjEnevfAsUXpflYNbiwq2Cul0p/9vhK3USVVqOogj3rrgY2y6/FWdKLKl4CB8Qhtjr1uasO2xw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/compose": {
+      "version": "2.1.42",
+      "resolved": "https://registry.npmjs.org/@thi.ng/compose/-/compose-2.1.42.tgz",
+      "integrity": "sha512-qcEPP6xs7CdWedNyRVMfbSJ/360KyG6JP0AFyv8Q6jbvJ1CiQ14moC4TjYQxl1LViVpTSpXQlOvg7LepYu7f9w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/errors": "^2.3.5"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/distance": {
+      "version": "2.4.21",
+      "resolved": "https://registry.npmjs.org/@thi.ng/distance/-/distance-2.4.21.tgz",
+      "integrity": "sha512-kgMRH3erTzyhtNqRdlwUCmj79i5Z12JoMKMRS59U56k3cWzPfPplCDGiYAB2e5h5lwX5cOkJBECbX/y09EV9SA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/checks": "^3.4.5",
+        "@thi.ng/errors": "^2.3.5",
+        "@thi.ng/heaps": "^2.1.40",
+        "@thi.ng/math": "^5.6.2",
+        "@thi.ng/vectors": "^7.7.19"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/equiv": {
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/@thi.ng/equiv/-/equiv-2.1.30.tgz",
+      "integrity": "sha512-Ci8arh+6IoZkJqCOXXQvC00BzLlAExmPVh9mpu55KEM1YqBRb6csBAea8mV3REpmze3nf9X4g6T4hEK023UXlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/errors": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@thi.ng/errors/-/errors-2.3.5.tgz",
+      "integrity": "sha512-WH2p02goxTCF11p8H/4VIl8RmPZ7rJ00ogFOrQX7mO3zxi1/vTqygR7sVuJszlx5a5eOrMglNivyqNZwr912cg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/heaps": {
+      "version": "2.1.40",
+      "resolved": "https://registry.npmjs.org/@thi.ng/heaps/-/heaps-2.1.40.tgz",
+      "integrity": "sha512-mv/pPY94CXpI/HIjOzWOQWjidW6goUiTlf2UN/YXEQWdh1kHiu7PmDDItdJrFY+MGiX57nl/+05nHR3UIKIMnw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/compare": "^2.2.0",
+        "@thi.ng/equiv": "^2.1.30"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/hex": {
+      "version": "2.3.17",
+      "resolved": "https://registry.npmjs.org/@thi.ng/hex/-/hex-2.3.17.tgz",
+      "integrity": "sha512-rfaeRg4pt+FuL84NxMaylHkER4YIN+OCrd0I/UWhad17qUIjYL5N5FyylVpDR8pYW32GbNYLGIVn92H32aaYYA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/k-means": {
+      "version": "0.6.36",
+      "resolved": "https://registry.npmjs.org/@thi.ng/k-means/-/k-means-0.6.36.tgz",
+      "integrity": "sha512-qnO+/P8wluOloQHRf+2y0oj+syOuli4FHELjOJOtZGjB1HWDKD8wRBV90x+8To/9oUUKZrBkqep8tmYZEEctyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/distance": "^2.4.21",
+        "@thi.ng/errors": "^2.3.5",
+        "@thi.ng/random": "^3.6.8",
+        "@thi.ng/vectors": "^7.7.19"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/math": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@thi.ng/math/-/math-5.6.2.tgz",
+      "integrity": "sha512-qjRihfyyW1UyPjNhK4Xs/lOF320yaVdn3cjKFycPJ/HoPyHmPmVaKX0A3bWswhB5VjK3UnKMgk4P1XUGK8tAmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/memoize": {
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@thi.ng/memoize/-/memoize-3.1.38.tgz",
+      "integrity": "sha512-/b8ad8jdNSLQ8/xVvokus1Xnbbm11HVyQUhDps67zpLiwt7XA44RATRmpyCHwR+RZlI7oUtqcNnSMNkVffue/Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/random": {
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/@thi.ng/random/-/random-3.6.8.tgz",
+      "integrity": "sha512-RRXi5YpKEpKhD3JubVD6yYD7TMH38vuCRC6q4eNHJe8kJ1wAfNLSD3P3W8H7ssMF1SE0sGsBtcby8ak/Y27N0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/checks": "^3.4.5",
+        "@thi.ng/errors": "^2.3.5",
+        "@thi.ng/hex": "^2.3.17"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/strings": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@thi.ng/strings/-/strings-3.6.0.tgz",
+      "integrity": "sha512-1d3ZHxdn2G+0F6LHqFHEgPUjUUtoQqI0wK5hgmjOsMUVjvPXlPLO9GtdWnv7Aa0jrRycYK2IbXQ2HqQDSZXpMg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/errors": "^2.3.5",
+        "@thi.ng/hex": "^2.3.17",
+        "@thi.ng/memoize": "^3.1.38"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/transducers": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/@thi.ng/transducers/-/transducers-8.8.2.tgz",
+      "integrity": "sha512-2+vkRWxjjPdTB4PlxJIMSnjVpraF5lB6fa3cE4yZv6KreZKlozA27lCjMwqoRcYT7oUPgrQC6vZ5bUXExf78aw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/arrays": "^2.6.3",
+        "@thi.ng/checks": "^3.4.5",
+        "@thi.ng/compare": "^2.2.0",
+        "@thi.ng/compose": "^2.1.42",
+        "@thi.ng/errors": "^2.3.5",
+        "@thi.ng/math": "^5.6.2",
+        "@thi.ng/random": "^3.6.8"
+      },
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/vectors": {
+      "version": "7.7.19",
+      "resolved": "https://registry.npmjs.org/@thi.ng/vectors/-/vectors-7.7.19.tgz",
+      "integrity": "sha512-COLIdpD8p8T3gUARDpgBpHpeybIWJxjBcS24hXYwmULdiY/6iA7uihyzv74tSDfOkum+YiIiF3eIbN5agzLDyA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.9.5",
+        "@thi.ng/binary": "^3.3.33",
+        "@thi.ng/checks": "^3.4.5",
+        "@thi.ng/equiv": "^2.1.30",
+        "@thi.ng/errors": "^2.3.5",
+        "@thi.ng/math": "^5.6.2",
+        "@thi.ng/memoize": "^3.1.38",
+        "@thi.ng/random": "^3.6.8",
+        "@thi.ng/strings": "^3.6.0",
+        "@thi.ng/transducers": "^8.8.2"
+      },
+      "engines": {
+        "node": ">=12.7"
       }
     },
     "node_modules/@tokenizer/token": {
@@ -13928,9 +14352,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
+    "@thi.ng/k-means": "^0.6.36",
     "@types/jimp": "^0.2.28",
     "@types/node": "18.16.1",
     "@types/react": "18.2.0",

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -21,7 +21,6 @@ import { batch } from 'react-redux';
 import { TextureFileType } from '@/utils/textures/files/textureFileTypeMap';
 import { decompressLzssBuffer } from '@/utils/data';
 import decompressVqBuffer from '@/utils/data/decompressVqBuffer';
-import compressVqBuffer from '@/utils/data/compressVqBuffer';
 
 const workerPool = new WorkerThreadPool();
 
@@ -115,13 +114,11 @@ export const initialModelDataState: ModelDataState = {
   hasCompressedTextures: false
 };
 
-// @TODO: decompress VQ image for 2nd and 3rd
-// texture when loading a character portrait file
 export const loadCharacterPortraitsFile = createAsyncThunk<
   LoadTexturesPayload,
   File,
   { state: AppState }
->(`${sliceName}/loadCharacterPortraitsFile`, async (file, { dispatch }) => {
+>(`${sliceName}/loadCharacterPortraitWsFile`, async (file, { dispatch }) => {
   const arrayBuffer = await file.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
 
@@ -228,9 +225,7 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
     { width: 64, height: 64 },
     { width: 256, height: 256, disableEdits: true },
     { width: 128, height: 128, disableEdits: true },
-    ...(pointers[3] ? [{ width: 64, height: 64 }] : []),
-    { width: 64, height: 64 },
-    { width: 128, height: 128 }
+    ...(pointers[3] ? [{ width: 64, height: 64 }] : [])
   ];
 
   const textureDefs = decompressedOffsets.map((offset, i) => ({

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -134,6 +134,7 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
   const jpLifebar = await decompressLzssBuffer(
     Buffer.from(compressedJpLifebarAssets)
   );
+  let compressedUsLifebar: Uint8Array | undefined;
   let usLifebar: Uint8Array | undefined;
 
   const compressedVq1Image = uint8Array.slice(pointers[1], pointers[2]);
@@ -154,10 +155,8 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
   );
 
   if (pointers[3]) {
-    const compressedUsLifebarAssets = uint8Array.slice(pointers[3]);
-    usLifebar = await decompressLzssBuffer(
-      Buffer.from(compressedUsLifebarAssets)
-    );
+    compressedUsLifebar = uint8Array.slice(pointers[3]);
+    usLifebar = await decompressLzssBuffer(Buffer.from(compressedUsLifebar));
   }
 
   const pointerBuffer = Buffer.alloc(startPointer);
@@ -207,9 +206,9 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
   }
 
   const trailingSection = new Uint8Array(buffer).slice(
-    usLifebar
-      ? pointerBuffer.readUint32LE(12) + usLifebar.length
-      : pointerBuffer.readUint32LE(8) + vq2Image.length
+    compressedUsLifebar
+      ? pointerBuffer.readUint32LE(12) + compressedUsLifebar.length
+      : pointerBuffer.readUint32LE(8) + compressedVq2Image.length
   );
 
   const decompressedBuffer = Buffer.concat([

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -209,12 +209,19 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
     );
   }
 
+  const trailingSection = new Uint8Array(buffer).slice(
+    usLifebar
+      ? pointerBuffer.readUint32LE(12) + usLifebar.length
+      : pointerBuffer.readUint32LE(8) + vq2Image.length
+  );
+
   const decompressedBuffer = Buffer.concat([
     pointerBuffer,
     jpLifebar,
     vq1Image,
     vq2Image,
-    ...(usLifebar ? [usLifebar] : [])
+    ...(usLifebar ? [usLifebar] : []),
+    trailingSection
   ]);
 
   const textureStructure: Partial<NLTextureDef>[] = [

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -21,6 +21,7 @@ import { batch } from 'react-redux';
 import { TextureFileType } from '@/utils/textures/files/textureFileTypeMap';
 import { decompressLzssBuffer } from '@/utils/data';
 import decompressVqBuffer from '@/utils/data/decompressVqBuffer';
+import compressVqBuffer from '@/utils/data/compressVqBuffer';
 
 const workerPool = new WorkerThreadPool();
 
@@ -138,10 +139,7 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
   );
   let usLifebar: Uint8Array | undefined;
 
-  console.log('uint8Array ->', uint8Array);
   const compressedVq1Image = uint8Array.slice(pointers[1], pointers[2]);
-  console.log('pointer 2 - 1 ->', pointers[2] - pointers[1]);
-  console.log('decompressed vq1 section ->', compressedVq1Image);
   const vq1Image = decompressVqBuffer(
     decompressLzssBuffer(Buffer.from(compressedVq1Image)),
     256,
@@ -175,7 +173,7 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
 
   if (pointers[3] !== undefined) {
     pointerBuffer.writeUInt32LE(
-      pointerBuffer.readUInt32LE(8) + (pointers[3] - pointers[2]),
+      pointerBuffer.readUInt32LE(8) + vq2Image.length,
       12
     );
   }
@@ -205,8 +203,10 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
   );
 
   if (usLifebar) {
-    const vqLength2 = vq2Image.length;
-    pointerBuffer.writeUInt32LE(pointerBuffer.readUInt32LE(8) + vqLength2, 12);
+    pointerBuffer.writeUInt32LE(
+      pointerBuffer.readUInt32LE(8) + vq2Image.length,
+      12
+    );
   }
 
   const decompressedBuffer = Buffer.concat([

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -217,10 +217,10 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
     ...(usLifebar ? [usLifebar] : [])
   ]);
 
-  const rleTextures = [
-    { width: 64, height: 64, colorFormat: 'RGB565' },
-    { width: 256, height: 256, colorFormat: 'RGB565' },
-    { width: 128, height: 128, colorFormat: 'RGB565' },
+  const textureStructure: Partial<NLTextureDef>[] = [
+    { width: 64, height: 64 },
+    { width: 256, height: 256, disableEdits: true },
+    { width: 128, height: 128, disableEdits: true },
     ...(pointers[3] ? [{ width: 64, height: 64 }] : []),
     { width: 64, height: 64 },
     { width: 128, height: 128 }
@@ -228,7 +228,7 @@ export const loadCharacterPortraitsFile = createAsyncThunk<
 
   const textureDefs = decompressedOffsets.map((offset, i) => ({
     colorFormat: 'RGB565',
-    ...rleTextures[i],
+    ...textureStructure[i],
     colorFormatValue: 2,
     bufferUrls: {
       translucent: undefined,

--- a/src/types/NLAbstractions.d.ts
+++ b/src/types/NLAbstractions.d.ts
@@ -100,6 +100,7 @@ export type NLTextureDef = {
   type: number;
   baseLocation: number;
   ramOffset: number;
+  disableEdits?: boolean;
   bufferUrls: {
     translucent?: string;
     opaque?: string;

--- a/src/utils/data/compressVqBuffer.ts
+++ b/src/utils/data/compressVqBuffer.ts
@@ -1,0 +1,61 @@
+import { kmeans } from '@thi.ng/k-means';
+import {
+  decodeZMortonPosition,
+  RgbaColor,
+  TextureColorFormat
+} from '../textures';
+import { rgb565ToRgba8888 } from '../color-conversions';
+
+const WORD_SIZE = 2;
+const VECTOR_LENGTH = 4;
+
+/** @param buffer decompressed buffer to compress */
+export default function compressVqBuffer(
+  buffer: Buffer,
+  imageFormat: TextureColorFormat
+) {
+  console.time('compressVqBuffer');
+
+  const codewords: number[][] = [];
+
+  for (let i = 0; i < buffer.length; i += 8) {
+    const w1 = buffer.readUInt16LE(i);
+    const w2 = buffer.length > i + 2 ? buffer.readUint16LE(i + 2) : 0;
+    const w3 = buffer.length > i + 4 ? buffer.readUint16LE(i + 4) : 0;
+    const w4 = buffer.length > i + 6 ? buffer.readUint16LE(i + 6) : 0;
+    const c1 = rgb565ToRgba8888(w1);
+    const c2 = rgb565ToRgba8888(w2);
+    const c3 = rgb565ToRgba8888(w3);
+    const c4 = rgb565ToRgba8888(w4);
+
+    const codeword = [
+      c1.r,
+      c1.g,
+      c1.b,
+      c2.r,
+      c2.g,
+      c2.b,
+      c3.r,
+      c3.g,
+      c3.b,
+      c4.r,
+      c4.g,
+      c4.b
+    ];
+
+    codewords.push(codeword);
+  }
+
+  const clusters = kmeans(256, codewords);
+  const indexWordMap = new Map<number, number>();
+
+  //assemble indexes into lookup for writing back
+  clusters.forEach((cluster: { items: number[] }, clusterIndex: number) => {
+    // @TODO: also break into rgb565 word to streamline writing back
+    cluster.items.forEach((item: number) => {
+      indexWordMap.set(item, clusterIndex);
+    });
+  });
+
+  console.timeEnd('compressVqBuffer');
+}

--- a/src/utils/data/compressVqBuffer.ts
+++ b/src/utils/data/compressVqBuffer.ts
@@ -1,16 +1,11 @@
 import { kmeans } from '@thi.ng/k-means';
-import { TextureColorFormat } from '../textures';
 import { rgb565ToRgba8888, rgbaToRgb565 } from '../color-conversions';
 
 const WORD_SIZE = 2;
 const VECTOR_LENGTH = 4;
 
 /** @param buffer decompressed buffer to compress */
-export default function compressVqBuffer(
-  buffer: Buffer,
-  /* @ TODO: use a conversion dict */
-  imageFormat: TextureColorFormat = 'RGB565'
-) {
+export default function compressVqBuffer(buffer: Buffer) {
   console.time('compressVqBuffer');
 
   const codewords: number[][] = [];

--- a/src/utils/data/decompressVqBuffer.ts
+++ b/src/utils/data/decompressVqBuffer.ts
@@ -1,13 +1,9 @@
-import { off } from 'process';
-import { encodeZMortonPosition } from '../textures';
-import { rgb565ToRgba8888, rgbaToRgb565 } from '../color-conversions';
-
 const WORD_SIZE = 2;
 const VECTOR_LENGTH = 4;
 const CODEBOOK_SIZE = 256;
 const CODEWORD_START = WORD_SIZE * VECTOR_LENGTH * CODEBOOK_SIZE;
 
-export default function vectorDequantizeBuffer(
+export default function decompressVqBuffer(
   bufferPassed: Buffer,
   w: number,
   h: number

--- a/src/utils/data/decompressVqBuffer.ts
+++ b/src/utils/data/decompressVqBuffer.ts
@@ -20,40 +20,22 @@ export default function vectorDequantizeBuffer(
     for (let i = 0; i < CODEBOOK_SIZE; i++) {
       const entry = [];
 
-      for (let j = 0; j < 4; j++) {
-        try {
-          const position = i * j * 2;
-          const word = buffer.readUInt16LE(position);
-          entry.push(word);
-        } catch (error) {
-          console.error('buffer length ->', buffer.length, 'i ->', i);
-        }
+      for (let j = 0; j < VECTOR_LENGTH; j++) {
+        const position = (i * VECTOR_LENGTH + j) * WORD_SIZE;
+        const word = buffer.readUInt16LE(position);
+        entry.push(word);
       }
-
       codebook.push(entry);
     }
 
-    const encode = (i) => encodeZMortonPosition(i % w, Math.floor(i / w));
-
     for (let i = 0; i < buffer.length - CODEWORD_START; i += 1) {
-      try {
-        const codewords = buffer.readUInt8(i + CODEWORD_START);
-        const vector = codebook[codewords];
-        const ai = i * 4;
-        const bi = i * 4 + 1;
-        const ci = i * 4 + 2;
-        const di = i * 4 + 3;
-        const max = Math.pow(2, 16) - 1;
+      const codewords = buffer.readUInt8(i + CODEWORD_START);
+      const vector = codebook[codewords];
 
-        const intensity = vector[0];
-        output[ai] = vector[0];
-        output[bi] = vector[1];
-        output[ci] = vector[2];
-        output[di] = vector[3];
-      } catch (error) {
-        console.log('error at i ->', i);
-        console.log('error ->', error);
-      }
+      output[i * 4] = vector[0];
+      output[i * 4 + 1] = vector[1];
+      output[i * 4 + 2] = vector[2];
+      output[i * 4 + 3] = vector[3];
     }
   } catch (error) {
     console.error(error);

--- a/src/utils/data/decompressVqBuffer.ts
+++ b/src/utils/data/decompressVqBuffer.ts
@@ -1,0 +1,69 @@
+import { off } from 'process';
+import { encodeZMortonPosition } from '../textures';
+import { rgb565ToRgba8888, rgbaToRgb565 } from '../color-conversions';
+
+const WORD_SIZE = 2;
+const VECTOR_LENGTH = 4;
+const CODEBOOK_SIZE = 256;
+const CODEWORD_START = WORD_SIZE * VECTOR_LENGTH * CODEBOOK_SIZE;
+
+export default function vectorDequantizeBuffer(
+  bufferPassed: Buffer,
+  w: number,
+  h: number
+) {
+  const buffer = Buffer.from(bufferPassed);
+  const codebook: number[][] = [];
+  const output: number[] = new Array(w * h);
+
+  try {
+    for (let i = 0; i < CODEBOOK_SIZE; i++) {
+      const entry = [];
+
+      for (let j = 0; j < 4; j++) {
+        try {
+          const position = i * j * 2;
+          const word = buffer.readUInt16LE(position);
+          entry.push(word);
+        } catch (error) {
+          console.error('buffer length ->', buffer.length, 'i ->', i);
+        }
+      }
+
+      codebook.push(entry);
+    }
+
+    const encode = (i) => encodeZMortonPosition(i % w, Math.floor(i / w));
+
+    for (let i = 0; i < buffer.length - CODEWORD_START; i += 1) {
+      try {
+        const codewords = buffer.readUInt8(i + CODEWORD_START);
+        const vector = codebook[codewords];
+        const ai = i * 4;
+        const bi = i * 4 + 1;
+        const ci = i * 4 + 2;
+        const di = i * 4 + 3;
+        const max = Math.pow(2, 16) - 1;
+
+        const intensity = vector[0];
+        output[ai] = vector[0];
+        output[bi] = vector[1];
+        output[ci] = vector[2];
+        output[di] = vector[3];
+      } catch (error) {
+        console.log('error at i ->', i);
+        console.log('error ->', error);
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  const outputBuffer = Buffer.from(new Uint8ClampedArray(output.length * 2));
+
+  for (let i = 0; i < output.length; i++) {
+    outputBuffer.writeUInt16LE(output[i], i * WORD_SIZE);
+  }
+
+  return outputBuffer;
+}

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -172,7 +172,7 @@ export default async function exportTextureFile({
 
       const compressedVq1Section = padBufferForAlignment(
         pointers[1],
-        compressLzssBuffer(compressVqBuffer(vq1Section, 'RGB565'))
+        compressLzssBuffer(compressVqBuffer(vq1Section))
       );
 
       const vq2Section = Buffer.from(
@@ -183,7 +183,7 @@ export default async function exportTextureFile({
 
       const compressedVq2Section = padBufferForAlignment(
         pointers[2],
-        compressLzssBuffer(compressVqBuffer(vq2Section, 'RGB565'))
+        compressLzssBuffer(compressVqBuffer(vq2Section))
       );
 
       buffer.writeUInt32LE(startPointer, 0);

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -12,6 +12,7 @@ import {
 } from '@/utils/textures';
 import { compressLzssBuffer, objectUrlToBuffer } from '@/utils/data';
 import { TextureFileType } from './textureFileTypeMap';
+import compressVqBuffer from '@/utils/data/compressVqBuffer';
 
 const COLOR_SIZE = 2;
 
@@ -75,11 +76,13 @@ export default async function exportTextureFile({
     );
 
     let quantizeOptions: QuantizeOptions | undefined;
+
     switch (textureFileType) {
       case 'mvc2-character-portraits': {
         quantizeOptions = {
           dithering: false,
-          colors: 64
+          // restrict colors further on smaller lifegauge imgs
+          colors: width === 64 ? 64 : 256
         };
         break;
       }
@@ -163,16 +166,29 @@ export default async function exportTextureFile({
         compressLzssBuffer(jpSection)
       );
 
+      const vq1Section = Buffer.from(
+        uint8Array.slice(pointers[1], pointers[2])
+      );
+
+      const compressedVq1Section = compressLzssBuffer(
+        compressVqBuffer(vq1Section, 'RGB565')
+      );
+
+      const vq2Section = Buffer.from(
+        uint8Array.slice(
+          ...[pointers[2], ...(pointers[3] ? [pointers[3]] : [])]
+        )
+      );
+
+      const compressedVq2Section = compressLzssBuffer(
+        compressVqBuffer(vq2Section, 'RGB565')
+      );
+
       buffer.writeUInt32LE(startPointer, 0);
       buffer.writeUInt32LE(startPointer + compressedJpSection.length, 4);
       buffer.writeUInt32LE(
-        startPointer + compressedJpSection.length + (pointers[2] - pointers[1]),
+        startPointer + compressedJpSection.length + compressedVq1Section.length,
         8
-      );
-
-      const vqContent = uint8Array.slice(
-        pointers[1],
-        pointers[3] !== undefined ? pointers[3] : undefined
       );
 
       let compressedUsSection;
@@ -185,11 +201,12 @@ export default async function exportTextureFile({
           startPointer,
           compressLzssBuffer(usSection)
         );
+
         buffer.writeUInt32LE(
           startPointer +
             compressedJpSection.length +
-            (pointers[2] - pointers[1]) +
-            (pointers[3] - pointers[2]),
+            compressedVq1Section.length +
+            compressedVq2Section.length,
           12
         );
       }
@@ -197,7 +214,8 @@ export default async function exportTextureFile({
       const outputBuffer = Buffer.concat([
         new Uint8Array(buffer).slice(0, startPointer),
         compressedJpSection,
-        vqContent,
+        compressedVq1Section,
+        compressedVq2Section,
         ...(compressedUsSection ? [compressedUsSection] : [])
       ]);
 

--- a/src/utils/textures/files/exportTextureFile.ts
+++ b/src/utils/textures/files/exportTextureFile.ts
@@ -170,20 +170,17 @@ export default async function exportTextureFile({
         uint8Array.slice(pointers[1], pointers[2])
       );
 
-      const compressedVq1Section = padBufferForAlignment(
-        pointers[1],
-        compressLzssBuffer(compressVqBuffer(vq1Section))
+      const compressedVq1Section = compressLzssBuffer(
+        compressVqBuffer(vq1Section)
       );
-
       const vq2Section = Buffer.from(
         uint8Array.slice(
           ...[pointers[2], ...(pointers[3] ? [pointers[3]] : [])]
         )
       );
 
-      const compressedVq2Section = padBufferForAlignment(
-        pointers[2],
-        compressLzssBuffer(compressVqBuffer(vq2Section))
+      const compressedVq2Section = compressLzssBuffer(
+        compressVqBuffer(vq2Section)
       );
 
       buffer.writeUInt32LE(startPointer, 0);

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -128,6 +128,7 @@ export default async function loadTextureFile({
       ...textureBufferData
     };
   } catch (error) {
+    console.error(error);
     // if an overflow error occurs, this is an indicator that the
     // file loaded is compressed; this is common for certain
     // game texture formats like Capcom vs SNK 2

--- a/src/utils/textures/parse/loadTextureFile.ts
+++ b/src/utils/textures/parse/loadTextureFile.ts
@@ -128,7 +128,6 @@ export default async function loadTextureFile({
       ...textureBufferData
     };
   } catch (error) {
-    console.error(error);
     // if an overflow error occurs, this is an indicator that the
     // file loaded is compressed; this is common for certain
     // game texture formats like Capcom vs SNK 2


### PR DESCRIPTION
Closes issue #93. Using an improved algorithm, the accuracy of resampled images for vector quantization is saved in a way that represents images better than the original game (!) -- though for UX purposes, some iteration will be needed to process on a worker thread (similar to import) + UI representation.

![image](https://github.com/rob2d/modnao/assets/1799905/71fed669-874c-491b-a280-b9f629639d13)

before:
![storm-ingame-og](https://github.com/rob2d/modnao/assets/1799905/5eb35ade-b40a-4041-9c89-c42afc39139e)
after:
![storm-ingame-resampled](https://github.com/rob2d/modnao/assets/1799905/d620a3bb-5f03-4de3-bf03-89190a6992a0)

