### PR TITLE
texture view iteration

### DIFF
--- a/src/components/SceneView.tsx
+++ b/src/components/SceneView.tsx
@@ -16,7 +16,7 @@ import {
   selectMeshSelectionType,
   selectModel,
   selectObjectKey,
-  selectSceneTextureDefs,
+  selectUpdatedTextureDefs,
   selectUneditedTextureUrls
 } from '@/store/selectors';
 import { setObjectKey, useAppDispatch, useAppSelector } from '@/store';
@@ -100,7 +100,7 @@ export default function SceneView() {
   );
 
   const uneditedTextureUrls = useAppSelector(selectUneditedTextureUrls);
-  const textureDefs = useAppSelector(selectSceneTextureDefs);
+  const textureDefs = useAppSelector(selectUpdatedTextureDefs);
   const model = useAppSelector(selectModel);
   const theme = useTheme();
 

--- a/src/components/SceneView.tsx
+++ b/src/components/SceneView.tsx
@@ -16,8 +16,8 @@ import {
   selectMeshSelectionType,
   selectModel,
   selectObjectKey,
-  selectUpdatedTextureDefs,
-  selectUneditedTextureUrls
+  selectUneditedTextureUrls,
+  selectUpdatedTextureDefs
 } from '@/store/selectors';
 import { setObjectKey, useAppDispatch, useAppSelector } from '@/store';
 import { useObjectNavControls } from '@/hooks';

--- a/src/components/TextureView.tsx
+++ b/src/components/TextureView.tsx
@@ -3,7 +3,11 @@ import { mdiMenuLeftOutline, mdiMenuRightOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import Img from 'next/image';
 import useViewportSizes from 'use-viewport-sizes';
-import { useObjectNavControls, useObjectUINav } from '@/hooks';
+import {
+  useObjectNavControls,
+  useObjectUINav,
+  useTextureReplaceDropzone
+} from '@/hooks';
 import {
   selectTextureIndex,
   selectUpdatedTextureDefs,
@@ -67,39 +71,14 @@ const Styled = styled('div')(
 
 export default function TextureView() {
   useObjectNavControls();
-  const dispatch = useAppDispatch();
   const uiControls = useObjectUINav();
   const [vpW] = useViewportSizes();
   const size = Math.round((vpW - 222) * 0.66);
   const textureIndex = useAppSelector(selectTextureIndex);
   const textureDefs = useAppSelector(selectUpdatedTextureDefs);
 
-  // @TODO: DRY w GuiPanelTexture
-  const onSelectNewImageFile = useCallback(
-    async (imageFile: File) => {
-      dispatch(selectReplacementTexture({ imageFile, textureIndex }));
-    },
-    [textureIndex]
-  );
-
-  const onDrop = useCallback(
-    async ([file]: File[]) => {
-      onSelectNewImageFile(file);
-    },
-    [onSelectNewImageFile]
-  );
-
-  const { getRootProps: getDragProps, isDragActive } = useDropzone({
-    onDrop,
-    multiple: false,
-    noClick: true,
-    accept: {
-      'image/bmp': ['.bmp'],
-      'image/png': ['.png'],
-      'image/jpeg': ['.jpg', '.jpeg'],
-      'image/gif': ['.gif']
-    }
-  });
+  const { isDragActive, getDragProps } =
+    useTextureReplaceDropzone(textureIndex);
 
   const textureUrl = textureDefs?.[textureIndex]?.dataUrls?.opaque;
 

--- a/src/components/TextureView.tsx
+++ b/src/components/TextureView.tsx
@@ -4,7 +4,11 @@ import Icon from '@mdi/react';
 import Img from 'next/image';
 import useViewportSizes from 'use-viewport-sizes';
 import { useObjectNavControls, useObjectUINav } from '@/hooks';
-import { selectTextureDefs, selectTextureIndex, useAppSelector } from '@/store';
+import {
+  selectTextureIndex,
+  selectUpdatedTextureDefs,
+  useAppSelector
+} from '@/store';
 
 const Styled = styled('div')(
   () =>
@@ -52,7 +56,7 @@ export default function TextureView() {
   const [vpW] = useViewportSizes();
   const size = Math.round((vpW - 222) * 0.66);
   const textureIndex = useAppSelector(selectTextureIndex);
-  const textureDefs = useAppSelector(selectTextureDefs);
+  const textureDefs = useAppSelector(selectUpdatedTextureDefs);
   const textureUrl = textureDefs?.[textureIndex]?.dataUrls?.opaque;
 
   return (

--- a/src/components/TextureView.tsx
+++ b/src/components/TextureView.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { IconButton, Skeleton, styled } from '@mui/material';
 import { mdiMenuLeftOutline, mdiMenuRightOutline } from '@mdi/js';
 import Icon from '@mdi/react';
@@ -11,14 +12,9 @@ import {
 import {
   selectTextureIndex,
   selectUpdatedTextureDefs,
-  useAppDispatch,
   useAppSelector
 } from '@/store';
-import { useDropzone } from 'react-dropzone';
-import { useCallback } from 'react';
-import clsx from 'clsx';
 import themeMixins from '@/theming/themeMixins';
-import { selectReplacementTexture } from '@/store/replaceTextureSlice';
 
 const Styled = styled('div')(
   ({ theme }) =>
@@ -32,13 +28,13 @@ const Styled = styled('div')(
       overflow-y: hidden;
     }
 
-    & .main-preview {
+    & .main {
       display: grid;
       flex-grow: 1;
       grid-template-columns: min-content auto min-content;
     }
 
-    & .main-preview > * {
+    & .main > * {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -57,6 +53,9 @@ const Styled = styled('div')(
     }
     
     & .texture-preview > div {
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transform: rotate(-90deg);
     }
 
@@ -84,7 +83,7 @@ export default function TextureView() {
 
   return (
     <Styled>
-      <div className='main-preview'>
+      <div className='main'>
         <IconButton
           className='model-nav-button'
           color='primary'

--- a/src/components/dialogs/replace-texture/ReplaceTexture.tsx
+++ b/src/components/dialogs/replace-texture/ReplaceTexture.tsx
@@ -34,7 +34,7 @@ import {
 } from '@/store';
 import { TextureColorFormat } from '@/utils/textures';
 import { objectUrlToBuffer } from '@/utils/data';
-import { useDebouncedEffect } from '@/hooks';
+import { useDebouncedEffect, useTextureReplaceDropzone } from '@/hooks';
 import cropImage from '@/utils/images/cropImage';
 import {
   applyReplacedTextureImage,
@@ -404,12 +404,8 @@ export default function ReplaceTexture() {
     200
   );
 
-  const onSelectNewImageFile = useCallback(
-    async (imageFile: File) => {
-      dispatch(updateReplacementTexture({ imageFile }));
-    },
-    [textureIndex]
-  );
+  const { getDragProps, isDragActive, onSelectNewImageFile } =
+    useTextureReplaceDropzone(textureIndex);
 
   const [
     openImageFileSelector,
@@ -429,25 +425,6 @@ export default function ReplaceTexture() {
 
     onSelectNewImageFile(selectedImageFile);
   }, [selectedImageFile]);
-
-  const onDrop = useCallback(
-    async ([file]: File[]) => {
-      onSelectNewImageFile(file);
-    },
-    [onSelectNewImageFile]
-  );
-
-  const { getRootProps: getDragProps, isDragActive } = useDropzone({
-    onDrop,
-    multiple: false,
-    noClick: true,
-    accept: {
-      'image/bmp': ['.bmp'],
-      'image/png': ['.png'],
-      'image/jpeg': ['.jpg', '.jpeg'],
-      'image/gif': ['.gif']
-    }
-  });
 
   useEffect(() => {
     (async () => {

--- a/src/components/dialogs/replace-texture/ReplaceTexture.tsx
+++ b/src/components/dialogs/replace-texture/ReplaceTexture.tsx
@@ -28,7 +28,6 @@ import {
   closeDialog,
   selectReplacementImage,
   selectReplacementTextureIndex,
-  selectTextureDefs,
   selectUpdatedTextureDefs,
   useAppDispatch,
   useAppSelector
@@ -45,6 +44,7 @@ import { NLTextureDef } from '@/types/NLAbstractions';
 import { useDropzone } from 'react-dropzone';
 import clsx from 'clsx';
 import { useFilePicker } from 'use-file-picker';
+import themeMixins from '@/theming/themeMixins';
 
 const Styled = styled('div')(
   ({ theme }) => `
@@ -65,17 +65,7 @@ const Styled = styled('div')(
 }
 
 & .content.file-drag-active:after {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: ${theme.palette.secondary.light};
-    border: 3px solid ${theme.palette.secondary.main};
-    mix-blend-mode: hard-light;
-    opacity: 0.75;
-    pointer-events: none;
+    ${themeMixins.fileDragActiveAfter}
 }
 
 & .section {

--- a/src/components/dialogs/replace-texture/ReplaceTexture.tsx
+++ b/src/components/dialogs/replace-texture/ReplaceTexture.tsx
@@ -36,12 +36,8 @@ import { TextureColorFormat } from '@/utils/textures';
 import { objectUrlToBuffer } from '@/utils/data';
 import { useDebouncedEffect, useTextureReplaceDropzone } from '@/hooks';
 import cropImage from '@/utils/images/cropImage';
-import {
-  applyReplacedTextureImage,
-  updateReplacementTexture
-} from '@/store/replaceTextureSlice';
+import { applyReplacedTextureImage } from '@/store/replaceTextureSlice';
 import { NLTextureDef } from '@/types/NLAbstractions';
-import { useDropzone } from 'react-dropzone';
 import clsx from 'clsx';
 import { useFilePicker } from 'use-file-picker';
 import themeMixins from '@/theming/themeMixins';

--- a/src/components/dialogs/replace-texture/ReplaceTexture.tsx
+++ b/src/components/dialogs/replace-texture/ReplaceTexture.tsx
@@ -29,6 +29,7 @@ import {
   selectReplacementImage,
   selectReplacementTextureIndex,
   selectTextureDefs,
+  selectUpdatedTextureDefs,
   useAppDispatch,
   useAppSelector
 } from '@/store';
@@ -284,7 +285,7 @@ export default function ReplaceTexture() {
     dispatch(applyReplacedTextureImage(processedRgba));
   }, [processedRgba, dispatch]);
 
-  const textureDefs: NLTextureDef[] = useAppSelector(selectTextureDefs);
+  const textureDefs: NLTextureDef[] = useAppSelector(selectUpdatedTextureDefs);
   const textureIndex = useAppSelector(selectReplacementTextureIndex);
   const replacementImage = useAppSelector(selectReplacementImage);
   const originalWidth = textureDefs?.[textureIndex]?.width || 0;

--- a/src/components/panel/GuiPanelTextures.tsx
+++ b/src/components/panel/GuiPanelTextures.tsx
@@ -9,7 +9,7 @@ import {
   selectModels,
   selectObjectMeshIndex,
   selectObjectPolygonIndex,
-  selectSceneTextureDefs,
+  selectUpdatedTextureDefs,
   selectSelectedTexture,
   selectTextureFileName,
   useAppDispatch,
@@ -38,7 +38,7 @@ export default function GuiPanelViewOptions() {
   const model = useAppSelector(selectModel);
   const meshIndex = useAppSelector(selectObjectMeshIndex);
   const canExportTextures = useAppSelector(selectCanExportTextures);
-  const textureDefs = useAppSelector(selectSceneTextureDefs);
+  const textureDefs = useAppSelector(selectUpdatedTextureDefs);
   const textureFileName = useAppSelector(selectTextureFileName);
   const selectedTexture = useAppSelector(selectSelectedTexture);
   const contentViewMode = useAppSelector(selectContentViewMode);

--- a/src/components/panel/GuiPanelTextures.tsx
+++ b/src/components/panel/GuiPanelTextures.tsx
@@ -9,9 +9,9 @@ import {
   selectModels,
   selectObjectMeshIndex,
   selectObjectPolygonIndex,
-  selectUpdatedTextureDefs,
   selectSelectedTexture,
   selectTextureFileName,
+  selectUpdatedTextureDefs,
   useAppDispatch,
   useAppSelector
 } from '@/store';

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -22,6 +22,7 @@ import { selectReplacementTexture } from '@/store/replaceTextureSlice';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import ContentViewMode from '@/types/ContentViewMode';
 import themeMixins from '@/theming/themeMixins';
+import { useTextureReplaceDropzone } from '@/hooks';
 
 const IMG_SIZE = '174px';
 
@@ -163,32 +164,8 @@ export default function GuiPanelTexture({
     contentViewMode !== 'polygons'
   ]);
 
-  // @TODO: DRY
-  const onSelectNewImageFile = useCallback(
-    async (imageFile: File) => {
-      dispatch(selectReplacementTexture({ imageFile, textureIndex }));
-    },
-    [textureIndex]
-  );
-
-  const onDrop = useCallback(
-    async ([file]: File[]) => {
-      onSelectNewImageFile(file);
-    },
-    [onSelectNewImageFile]
-  );
-
-  const { getRootProps: getDragProps, isDragActive } = useDropzone({
-    onDrop,
-    multiple: false,
-    noClick: true,
-    accept: {
-      'image/bmp': ['.bmp'],
-      'image/png': ['.png'],
-      'image/jpeg': ['.jpg', '.jpeg'],
-      'image/gif': ['.gif']
-    }
-  });
+  const { getDragProps, isDragActive, onSelectNewImageFile } =
+    useTextureReplaceDropzone(textureIndex);
 
   const { width, height } = textureDef;
 

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -21,6 +21,7 @@ import { SourceTextureData, uvToCssPathPoint } from '@/utils/textures';
 import { selectReplacementTexture } from '@/store/replaceTextureSlice';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import ContentViewMode from '@/types/ContentViewMode';
+import themeMixins from '@/theming/themeMixins';
 
 const IMG_SIZE = '174px';
 
@@ -42,17 +43,7 @@ const StyledPanelTexture = styled('div')(
   }
 
   & .image-area.file-drag-active:after {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: ${theme.palette.secondary.light};
-    border: 3px solid ${theme.palette.secondary.main};
-    mix-blend-mode: hard-light;
-    opacity: 0.75;
-    pointer-events: none;
+    ${themeMixins.fileDragActiveAfter(theme)}
   }
     
   & .img {

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -75,7 +75,7 @@ const StyledPanelTexture = styled('div')(
     opacity: 0.25;
   }
 
-  &.mode-textures {
+  &.mode-textures.selectable {
     cursor: pointer;
   }
 
@@ -265,6 +265,7 @@ export default function GuiPanelTexture({
     <StyledPanelTexture
       className={clsx(
         `mode-${contentViewMode}`,
+        isSelectable && 'selectable',
         viewOptions.uvRegionsHighlighted && 'uvs-enabled'
       )}
     >

--- a/src/components/panel/textures/GuiPanelTexture.tsx
+++ b/src/components/panel/textures/GuiPanelTexture.tsx
@@ -163,6 +163,7 @@ export default function GuiPanelTexture({
     contentViewMode !== 'polygons'
   ]);
 
+  // @TODO: DRY
   const onSelectNewImageFile = useCallback(
     async (imageFile: File) => {
       dispatch(selectReplacementTexture({ imageFile, textureIndex }));

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { default as useHeldRepetitionTimer } from './useHeldRepetitionTimer';
 export { default as useDebouncedEffect } from './useDebouncedEffect';
 export { default as useSceneGLTFFileDownloader } from './useSceneGLTFFileDownloader';
 export { default as useSupportedFilePicker } from './useSupportedFilePicker';
+export { default as useTextureReplaceDropzone } from './useTextureReplaceDropzone';

--- a/src/hooks/useTextureReplaceDropzone.ts
+++ b/src/hooks/useTextureReplaceDropzone.ts
@@ -27,7 +27,9 @@ export default function useTextureReplaceDropzone(textureIndex: number) {
       'image/bmp': ['.bmp'],
       'image/png': ['.png'],
       'image/jpeg': ['.jpg', '.jpeg'],
-      'image/gif': ['.gif']
+      'image/gif': ['.gif'],
+      'image/tiff': ['.tif', '.tiff'],
+      'image/webp': ['.webp']
     }
   });
 

--- a/src/hooks/useTextureReplaceDropzone.ts
+++ b/src/hooks/useTextureReplaceDropzone.ts
@@ -1,0 +1,35 @@
+import { useAppDispatch } from '@/store';
+import { selectReplacementTexture } from '@/store/replaceTextureSlice';
+import { useCallback } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+export default function useTextureReplaceDropzone(textureIndex: number) {
+  const dispatch = useAppDispatch();
+  const onSelectNewImageFile = useCallback(
+    async (imageFile: File) => {
+      dispatch(selectReplacementTexture({ imageFile, textureIndex }));
+    },
+    [textureIndex]
+  );
+
+  const onDrop = useCallback(
+    async ([file]: File[]) => {
+      onSelectNewImageFile(file);
+    },
+    [onSelectNewImageFile]
+  );
+
+  const { getRootProps: getDragProps, isDragActive } = useDropzone({
+    onDrop,
+    multiple: false,
+    noClick: true,
+    accept: {
+      'image/bmp': ['.bmp'],
+      'image/png': ['.png'],
+      'image/jpeg': ['.jpg', '.jpeg'],
+      'image/gif': ['.gif']
+    }
+  });
+
+  return { getDragProps, isDragActive, onDrop, onSelectNewImageFile };
+}

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -12,8 +12,8 @@ import { AppState } from './store';
 import HslValues from '@/utils/textures/HslValues';
 import {
   selectHasCompressedTextures,
-  selectUpdatedTextureDefs,
-  selectTextureFileType
+  selectTextureFileType,
+  selectUpdatedTextureDefs
 } from './selectors';
 import { SourceTextureData } from '@/utils/textures/SourceTextureData';
 import WorkerThreadPool from '../utils/WorkerThreadPool';

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -12,7 +12,7 @@ import { AppState } from './store';
 import HslValues from '@/utils/textures/HslValues';
 import {
   selectHasCompressedTextures,
-  selectSceneTextureDefs,
+  selectUpdatedTextureDefs,
   selectTextureFileType
 } from './selectors';
 import { SourceTextureData } from '@/utils/textures/SourceTextureData';
@@ -715,7 +715,7 @@ export const downloadTextureFile = createAsyncThunk<
 >(`${sliceName}/downloadTextureFile`, async (_, { getState }) => {
   const state = getState();
   const { textureFileName, textureBufferUrl } = state.modelData;
-  const textureDefs = selectSceneTextureDefs(state);
+  const textureDefs = selectUpdatedTextureDefs(state);
   const textureFileType = selectTextureFileType(state);
   const isCompressedTexture = selectHasCompressedTextures(state);
 

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -57,7 +57,7 @@ export const selectEditedTextures = (s: AppState) => s.modelData.editedTextures;
  * combines texture defs with any edited data urls
  * to display on scene in real-time
  */
-export const selectSceneTextureDefs = createSelector(
+export const selectUpdatedTextureDefs = createSelector(
   selectTextureDefs,
   selectEditedTextures,
   (textureDefs, bufferUrlEntries): typeof textureDefs => {
@@ -97,7 +97,7 @@ export const selectModel = createSelector(
 export type DisplayedMesh = NLMesh & { textureHash: string };
 export const selectDisplayedMeshes = createSelector(
   selectModel,
-  selectSceneTextureDefs,
+  selectUpdatedTextureDefs,
   (model, textureDefs) =>
     (model?.meshes || []).reduce<DisplayedMesh[]>((meshes, m) => {
       const tDef = textureDefs[m.textureIndex];

--- a/src/theming/themeMixins.ts
+++ b/src/theming/themeMixins.ts
@@ -1,0 +1,19 @@
+import { Theme } from '@mui/material/styles';
+
+const themeMixins = {
+  fileDragActiveAfter: (theme: Theme) => `
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: ${theme.palette.secondary.light};
+    border: 3px solid ${theme.palette.secondary.main};
+    mix-blend-mode: hard-light;
+    opacity: 0.75;
+    pointer-events: none;
+  `
+};
+
+export default themeMixins;


### PR DESCRIPTION
Adds dropzone to replace full texture replacement view, allows TIFF/WebP images, fixes a few issues from rough first iteration and cleans up and DRYs/iterates on existing code to facilitate the same.
![texture-view-dropzone_edit_0](https://github.com/rob2d/modnao/assets/1799905/a032a5ec-45fc-4775-b930-73069879ea35)
