### PR TITLE
DRY texture loading logic in model data slice

### DIFF
--- a/src/hooks/useSupportedFilePicker.ts
+++ b/src/hooks/useSupportedFilePicker.ts
@@ -3,7 +3,6 @@ import { useFilePicker } from 'use-file-picker';
 import {
   loadCharacterPortraitsFile,
   loadPolygonFile,
-  loadStandardCompressedTexture,
   loadTextureFile,
   useAppDispatch,
   useAppSelector
@@ -117,9 +116,10 @@ export const handleFileInput = async (
     case 'mvc2-selection-textures':
     case 'mvc2-end-file': {
       dispatch(
-        loadStandardCompressedTexture({
+        loadTextureFile({
           file: selectedTextureFile,
-          textureFileType
+          textureFileType,
+          isCompressed: true
         })
       );
       break;

--- a/src/hooks/useSupportedFilePicker.ts
+++ b/src/hooks/useSupportedFilePicker.ts
@@ -2,11 +2,8 @@ import { useEffect } from 'react';
 import { useFilePicker } from 'use-file-picker';
 import {
   loadCharacterPortraitsFile,
-  loadMvc2CharacterWinFile,
-  loadMvc2EndFile,
-  loadMvc2SelectionTexturesFile,
-  loadMvc2StagePreviewsFile,
   loadPolygonFile,
+  loadStandardCompressedTexture,
   loadTextureFile,
   useAppDispatch,
   useAppSelector
@@ -115,20 +112,16 @@ export const handleFileInput = async (
       dispatch(loadCharacterPortraitsFile(selectedTextureFile));
       break;
     }
-    case 'mvc2-character-win': {
-      dispatch(loadMvc2CharacterWinFile(selectedTextureFile));
-      break;
-    }
-    case 'mvc2-stage-preview': {
-      dispatch(loadMvc2StagePreviewsFile(selectedTextureFile));
-      break;
-    }
-    case 'mvc2-selection-textures': {
-      dispatch(loadMvc2SelectionTexturesFile(selectedTextureFile));
-      break;
-    }
+    case 'mvc2-character-win':
+    case 'mvc2-stage-preview':
+    case 'mvc2-selection-textures':
     case 'mvc2-end-file': {
-      dispatch(loadMvc2EndFile(selectedTextureFile));
+      dispatch(
+        loadStandardCompressedTexture({
+          file: selectedTextureFile,
+          textureFileType
+        })
+      );
       break;
     }
     default: {

--- a/src/store/modelDataSlice.ts
+++ b/src/store/modelDataSlice.ts
@@ -21,8 +21,8 @@ import { TextureFileType } from '@/utils/textures/files/textureFileTypeMap';
 import { decompressLzssBuffer } from '@/utils/data';
 import decompressVqBuffer from '@/utils/data/decompressVqBuffer';
 import { ClientThread } from '@/utils/threads';
-import { createTextureDef } from '@/utils/textures';
 import { createAppAsyncThunk } from './typedFunctions';
+import textureShapesMap from '@/utils/textures/files/textureShapesMap';
 
 export type LoadPolygonsResult = {
   type: 'loadPolygonFile';
@@ -183,7 +183,7 @@ export const loadCharacterPortraitsFile = createAppAsyncThunk(
     }
 
     let position = startPointer;
-    const decompressedOffsets = [];
+    const decompressedOffsets: number[] = [];
     decompressedOffsets.push(position);
 
     position += jpLifebar.length;
@@ -236,38 +236,23 @@ export const loadCharacterPortraitsFile = createAppAsyncThunk(
       tSectionBytes
     ]);
 
-    const textureStructure: Partial<NLTextureDef>[] = [
-      { width: 64, height: 64 },
-      { width: 256, height: 256, disableEdits: true },
-      { width: 128, height: 128, disableEdits: true },
-      ...(pointers[3] ? [{ width: 64, height: 64 }] : [])
-    ];
-
-    const textureDefs = decompressedOffsets.map((offset, i) =>
-      createTextureDef({
-        colorFormat: 'RGB565',
-        ...textureStructure[i],
-        colorFormatValue: 2,
-        baseLocation: offset
-      })
-    );
+    const textureDefs = textureShapesMap['mvc2-character-portraits']
+      .slice(0, pointers.length)
+      .map((d, i) => ({ ...d, baseLocation: decompressedOffsets[i] }));
 
     const thread = new ClientThread();
 
     const result: LoadTexturesPayload = await new Promise<LoadTexturesPayload>(
       (resolve) => {
+        const textureFileType = 'mvc2-character-portraits';
         thread.onmessage = (event: MessageEvent<LoadTexturesResult>) => {
           const payload: LoadTexturesPayload = {
             ...event.data.result,
             hasCompressedTextures: true,
-            textureFileType: 'mvc2-character-portraits'
+            textureFileType
           };
 
-          handleTextureLoadFulfilled(
-            dispatch,
-            'mvc2-character-portraits',
-            payload
-          );
+          handleTextureLoadFulfilled(dispatch, textureFileType, payload);
 
           resolve(payload);
           thread.unallocate();
@@ -345,134 +330,20 @@ const handleTextureLoadFulfilled = (
     });
   });
 
-export const loadMvc2CharacterWinFile = createAppAsyncThunk(
-  `${sliceName}/loadMvc2CharacterWinFile`,
-  async (file: File, { dispatch }) => {
-    const textureDefs: NLTextureDef[] = [
-      createTextureDef({
-        width: 256,
-        height: 256,
-        colorFormat: 'ARGB4444',
-        colorFormatValue: 2
-      })
-    ];
+export const loadStandardCompressedTexture = createAppAsyncThunk(
+  `${sliceName}loadStandardCompressedTexture`,
+  async (
+    { file, textureFileType }: { file: File; textureFileType: TextureFileType },
+    { dispatch }
+  ) => {
+    const textureDefs = textureShapesMap[textureFileType];
 
     const result = (await loadCompressedTextureFile(
       file,
-      'mvc2-character-win',
+      textureFileType,
       textureDefs,
       (payload: LoadTexturesPayload) =>
-        handleTextureLoadFulfilled(dispatch, 'mvc2-character-win', payload)
-    )) as LoadTexturesPayload;
-
-    return result;
-  }
-);
-
-export const loadMvc2StagePreviewsFile = createAppAsyncThunk(
-  `${sliceName}/loadMvc2StagePreviewsFile`,
-  async (file: File, { dispatch }) => {
-    const textureDefs: NLTextureDef[] = [];
-
-    for (let i = 0; i < 18; i++) {
-      textureDefs.push(
-        createTextureDef({
-          width: 128,
-          height: 128,
-          colorFormat: 'RGB565',
-          colorFormatValue: 2,
-          baseLocation: i * 128 * 128 * 2
-        })
-      );
-    }
-
-    textureDefs.push(
-      createTextureDef({
-        width: 64,
-        height: 64,
-        colorFormat: 'ARGB4444',
-        colorFormatValue: 2,
-        baseLocation: 18 * 128 * 128 * 2
-      })
-    );
-
-    const result = (await loadCompressedTextureFile(
-      file,
-      'mvc2-stage-preview',
-      textureDefs,
-      (payload: LoadTexturesPayload) =>
-        handleTextureLoadFulfilled(dispatch, 'mvc2-stage-preview', payload)
-    )) as LoadTexturesPayload;
-
-    return result;
-  }
-);
-
-export const loadMvc2EndFile = createAppAsyncThunk<
-  LoadTexturesPayload,
-  File,
-  { state: AppState }
->(`${sliceName}/loadMvc2EndFile`, async (file, { dispatch }) => {
-  const textureDefs: NLTextureDef[] = [];
-
-  for (let i = 0; i < 16; i++) {
-    textureDefs.push(
-      createTextureDef({
-        width: 256,
-        height: 256,
-        colorFormat: 'RGB565',
-        colorFormatValue: 2,
-        baseLocation: i * 256 * 256 * 2
-      })
-    );
-  }
-
-  textureDefs.push(
-    createTextureDef({
-      width: 128,
-      height: 128,
-      colorFormat: 'ARGB4444',
-      colorFormatValue: 2,
-      baseLocation: 256 * 256 * 16 * 2
-    })
-  );
-
-  textureDefs.push(
-    createTextureDef({
-      width: 128,
-      height: 128,
-      colorFormat: 'ARGB4444',
-      colorFormatValue: 2,
-      baseLocation: 256 * 256 * 16 * 2 + 128 * 128 * 2
-    })
-  );
-
-  const result = (await loadCompressedTextureFile(
-    file,
-    'mvc2-end-file',
-    textureDefs,
-    (payload: LoadTexturesPayload) =>
-      handleTextureLoadFulfilled(dispatch, 'mvc2-end-file', payload)
-  )) as LoadTexturesPayload;
-
-  return result;
-});
-
-export const loadMvc2SelectionTexturesFile = createAppAsyncThunk(
-  `${sliceName}/loadMvc2SelectionTexturesFile`,
-  async (file: File, { dispatch }) => {
-    const textureDefs: NLTextureDef[] = [...Array(23).keys()].map((i) =>
-      createTextureDef({
-        baseLocation: 256 * 256 * 2 * i
-      })
-    );
-
-    const result = (await loadCompressedTextureFile(
-      file,
-      'mvc2-selection-textures',
-      textureDefs,
-      (payload: LoadTexturesPayload) =>
-        handleTextureLoadFulfilled(dispatch, 'mvc2-selection-textures', payload)
+        handleTextureLoadFulfilled(dispatch, textureFileType, payload)
     )) as LoadTexturesPayload;
 
     return result;
@@ -535,11 +406,7 @@ export const loadTextureFile = createAppAsyncThunk(
       const fileName = file.name;
       thread.postMessage({
         type: 'loadTextureFile',
-        payload: {
-          fileName,
-          textureDefs,
-          buffer
-        }
+        payload: { fileName, textureDefs, buffer }
       } as WorkerEvent);
     });
 

--- a/src/utils/textures/files/textureShapesMap.ts
+++ b/src/utils/textures/files/textureShapesMap.ts
@@ -2,6 +2,14 @@ import { NLTextureDef } from '@/types/NLAbstractions';
 import createTextureDef from '../createTextureDef';
 import { TextureFileType } from './textureFileTypeMap';
 
+const mvc2PlFacStructure: Partial<NLTextureDef>[] = [
+  { width: 64, height: 64 },
+  { width: 256, height: 256 },
+  { width: 128, height: 128 },
+  // may be omitted based on if last pointer exists
+  { width: 64, height: 64 }
+];
+
 const fontTextureArgs: Partial<NLTextureDef> = {
   width: 128,
   height: 128,
@@ -10,7 +18,14 @@ const fontTextureArgs: Partial<NLTextureDef> = {
 };
 
 const textureShapesMap: Record<TextureFileType, NLTextureDef[]> = {
-  'mvc2-character-portraits': [],
+  'mvc2-character-portraits': mvc2PlFacStructure.map((t) =>
+    createTextureDef({
+      ...t,
+      colorFormat: 'RGB565',
+      colorFormatValue: 1,
+      baseLocation: 0 //TODO: determine how to use these/how these will be injected
+    })
+  ),
   'mvc2-stage-preview': [
     ...[...Array(18).keys()].map((i) =>
       createTextureDef({
@@ -37,11 +52,9 @@ const textureShapesMap: Record<TextureFileType, NLTextureDef[]> = {
       colorFormatValue: 2
     })
   ],
-  'mvc2-selection-textures': [
-    ...[...Array(23).keys()].map((i) =>
-      createTextureDef({ baseLocation: 256 * 256 * 2 * i })
-    )
-  ],
+  'mvc2-selection-textures': [...Array(23).keys()].map((i) =>
+    createTextureDef({ baseLocation: 256 * 256 * 2 * i })
+  ),
   'mvc2-end-file': [
     ...[...Array(16).keys()].map((i) =>
       createTextureDef({

--- a/src/utils/textures/files/textureShapesMap.ts
+++ b/src/utils/textures/files/textureShapesMap.ts
@@ -1,0 +1,68 @@
+import { NLTextureDef } from '@/types/NLAbstractions';
+import createTextureDef from '../createTextureDef';
+import { TextureFileType } from './textureFileTypeMap';
+
+const fontTextureArgs: Partial<NLTextureDef> = {
+  width: 128,
+  height: 128,
+  colorFormat: 'ARGB4444',
+  colorFormatValue: 2
+};
+
+const textureShapesMap: Record<TextureFileType, NLTextureDef[]> = {
+  'mvc2-character-portraits': [],
+  'mvc2-stage-preview': [
+    ...[...Array(18).keys()].map((i) =>
+      createTextureDef({
+        width: 128,
+        height: 128,
+        colorFormat: 'RGB565',
+        colorFormatValue: 1,
+        baseLocation: i * 128 * 128 * 2
+      })
+    ),
+    createTextureDef({
+      width: 64,
+      height: 64,
+      colorFormat: 'ARGB4444',
+      colorFormatValue: 2,
+      baseLocation: 18 * 128 * 128 * 2
+    })
+  ],
+  'mvc2-character-win': [
+    createTextureDef({
+      width: 256,
+      height: 256,
+      colorFormat: 'ARGB4444',
+      colorFormatValue: 2
+    })
+  ],
+  'mvc2-selection-textures': [
+    ...[...Array(23).keys()].map((i) =>
+      createTextureDef({ baseLocation: 256 * 256 * 2 * i })
+    )
+  ],
+  'mvc2-end-file': [
+    ...[...Array(16).keys()].map((i) =>
+      createTextureDef({
+        width: 256,
+        height: 256,
+        colorFormat: 'RGB565',
+        colorFormatValue: 1,
+        baseLocation: i * 256 * 256 * 2
+      })
+    ),
+    createTextureDef({
+      ...fontTextureArgs,
+      baseLocation: 256 * 256 * 16 * 2
+    }),
+    createTextureDef({
+      ...fontTextureArgs,
+      baseLocation: 256 * 256 * 16 * 2 + 128 * 128 * 2
+    })
+  ],
+  // will be populated with headers in polygon file
+  'polygon-mapped': []
+};
+
+export default textureShapesMap;


### PR DESCRIPTION
Now that compression is sorted for VQ and LZSS, and new texture view is done, will be good for future enhancements to cut down on a lot of known redundancy so that compressed texture formats all share/re-use common thunk and worker messaging logic.