### PR TITLE
handle culling flag in renders

### DIFF
--- a/src/components/scene/RenderedPolygon.tsx
+++ b/src/components/scene/RenderedPolygon.tsx
@@ -12,6 +12,7 @@ import { Select } from '@react-three/postprocessing';
 type Point3D = [x: number, y: number, z: number];
 
 export default function RenderedPolygon({
+  flags,
   vertexGroupMode,
   vertices,
   indices,
@@ -139,9 +140,9 @@ export default function RenderedPolygon({
       transparent: true,
       opacity: 1,
       alphaTest: 0.0001,
-      side: disableBackfaceCulling ? DoubleSide : FrontSide
+      side: disableBackfaceCulling || !flags.culling ? DoubleSide : FrontSide
     }),
-    [texture, isSelected, disableBackfaceCulling]
+    [texture, isSelected, disableBackfaceCulling || !flags.culling]
   );
 
   const handleClick = (e: ThreeEvent<MouseEvent>) => {

--- a/src/utils/polygons/parse/getPolyTypeFlags.ts
+++ b/src/utils/polygons/parse/getPolyTypeFlags.ts
@@ -1,6 +1,6 @@
 const getPolyTypeFlags = (v: number): PolyTypeFlags => ({
-  culling: ((v >> 1) & 1) == 1,
   cullingType: ((v >> 0) & 1) == 1 ? 'back' : 'front',
+  culling: ((v >> 1) & 1) == 1,
   spriteQuad: ((v >> 2) & 1) == 1,
   triangles: ((v >> 3) & 1) == 1,
   strip: ((v >> 4) & 1) == 1,


### PR DESCRIPTION
Was causing issues on a few niche cases in polygon texture mappings where holes appeared -- just needed to account for culling flag (which was already parsed from the binaries).

before
![image](https://github.com/rob2d/modnao/assets/1799905/c49d01a1-7caa-4884-ad81-75f89633b902)

after
![image](https://github.com/rob2d/modnao/assets/1799905/ca98f4c3-1e99-4384-998e-c07f33c73f96)
