### PR TITLE
add new ui option/feature: export all models to .gltf button

### DIFF
--- a/src/components/panel/GuiPanelModels.tsx
+++ b/src/components/panel/GuiPanelModels.tsx
@@ -51,7 +51,9 @@ export default function GuiPanelModels() {
 
   const objectKey = useAppSelector(selectObjectKey);
   const meshSelectionType = useAppSelector(selectMeshSelectionType);
-  const onExportGLTFFile = useSceneGLTFFileDownloader();
+  const onExportToGLTF = useSceneGLTFFileDownloader(false);
+  const onExportAllToGLTF = useSceneGLTFFileDownloader(true);
+
   const onExportSelectionJson = useModelSelectionExport();
   const onSetMeshSelectionType = useCallback(
     (_: React.MouseEvent<HTMLElement>, type: 'mesh' | 'polygon') => {
@@ -193,18 +195,26 @@ export default function GuiPanelModels() {
           </Grid>
         </Grid>
         {importFiles}
-        {
-          <GuiPanelButton
-            tooltip={
-              'Export a .gltf file representing the currently viewed in-scene model ' +
-              'meshes and textures to import into Maya or Blender.'
-            }
-            onClick={onExportGLTFFile}
-            color='secondary'
-          >
-            Export Scene .GLTF
-          </GuiPanelButton>
-        }
+        <GuiPanelButton
+          tooltip={
+            'Export a .gltf file representing the currently viewed in-scene model ' +
+            'meshes and textures to import into Maya or Blender.'
+          }
+          onClick={onExportToGLTF}
+          color='secondary'
+        >
+          Export Scene .GLTF
+        </GuiPanelButton>
+        <GuiPanelButton
+          tooltip={
+            'Export a .gltf file representing *all* viewable model' +
+            'meshes and textures to import into Maya or Blender.'
+          }
+          onClick={onExportAllToGLTF}
+          color='secondary'
+        >
+          Export Models .GLTF
+        </GuiPanelButton>
         {exportSelectionButton}
       </div>
     </GuiPanelSection>

--- a/src/contexts/ViewOptionsContext.spec.tsx
+++ b/src/contexts/ViewOptionsContext.spec.tsx
@@ -21,7 +21,8 @@ const booleanSetterKeys = [
   'setDevOptionsVisible',
   'setUvRegionsHighlighted',
   'setDisableBackfaceCulling',
-  'setEnableVertexColors'
+  'setEnableVertexColors',
+  'setRenderAllModels'
 ] as const;
 
 const booleanStorageKeys: Set<string> = new Set([
@@ -102,7 +103,8 @@ describe('ViewOptionsContext', () => {
       'disableBackfaceCulling: true',
       'uvRegionsHighlighted: false',
       'devOptionsVisible: true',
-      'enableVertexColors: false'
+      'enableVertexColors: false',
+      'renderAllModels: false'
     ];
 
     displayedValues.forEach((d) =>
@@ -131,7 +133,8 @@ describe('ViewOptionsContext', () => {
       'disableBackfaceCulling: true',
       'uvRegionsHighlighted: true',
       'devOptionsVisible: true',
-      'enableVertexColors: true'
+      'enableVertexColors: true',
+      'renderAllModels: true'
     ];
 
     for (const v of displayedValues) {
@@ -154,7 +157,8 @@ describe('ViewOptionsContext', () => {
       'disableBackfaceCulling: false',
       'uvRegionsHighlighted: false',
       'devOptionsVisible: false',
-      'enableVertexColors: false'
+      'enableVertexColors: false',
+      'renderAllModels: false'
     ];
 
     for (const v of displayedValues) {
@@ -172,7 +176,8 @@ describe('ViewOptionsContext', () => {
       'disableBackfaceCulling: true',
       'uvRegionsHighlighted: true',
       'devOptionsVisible: true',
-      'enableVertexColors: true'
+      'enableVertexColors: true',
+      'renderAllModels: true'
     ];
 
     for (const id of trueSetterTestIds) {

--- a/src/contexts/ViewOptionsContext.tsx
+++ b/src/contexts/ViewOptionsContext.tsx
@@ -25,6 +25,7 @@ export type ViewOptions = {
   themeKey?: 'light' | 'dark';
   scenePalette?: ScenePalette;
   devOptionsVisible: boolean;
+  renderAllModels: boolean;
   setAxesHelperVisible: (axesHelperVisible: boolean) => void;
   setSceneCursorVisible: (sceneCursorVisible: boolean) => void;
   setGuiPanelVisible: (guiPanelVisible: boolean) => void;
@@ -38,6 +39,7 @@ export type ViewOptions = {
   setThemeKey: (theme: 'light' | 'dark') => void;
   toggleLightDarkTheme: () => void;
   setDevOptionsVisible: (devOptions: boolean) => void;
+  setRenderAllModels: (devOptions: boolean) => void;
 };
 
 export const defaultValues: ViewOptions = {
@@ -53,6 +55,7 @@ export const defaultValues: ViewOptions = {
   themeKey: 'light',
   scenePalette: undefined,
   devOptionsVisible: false,
+  renderAllModels: false,
   setAxesHelperVisible: (_: boolean) => null,
   setSceneCursorVisible: (_: boolean) => null,
   setGuiPanelVisible: (_: boolean) => null,
@@ -65,7 +68,8 @@ export const defaultValues: ViewOptions = {
   setScenePalette: (_: ScenePalette | undefined) => null,
   setThemeKey: (_: 'light' | 'dark') => null,
   toggleLightDarkTheme: () => null,
-  setDevOptionsVisible: (_: boolean) => null
+  setDevOptionsVisible: (_: boolean) => null,
+  setRenderAllModels: (_: boolean) => null
 } as const;
 export const ViewOptionsContext =
   React.createContext<ViewOptions>(defaultValues);
@@ -73,7 +77,12 @@ export const ViewOptionsContext =
 type Props = { children: ReactNode };
 
 export function ViewOptionsContextProvider({ children }: Props) {
-  const [axesHelperVisible, handleSetAxesHelperVisible] = useState(true);
+  const [axesHelperVisible, handleSetAxesHelperVisible] = useState(
+    defaultValues.axesHelperVisible
+  );
+  const [renderAllModels, handleSetRenderAllModels] = useState(
+    defaultValues.renderAllModels
+  );
   const [objectAddressesVisible, handleSetObjectAddressesVisible] = useState(
     defaultValues.objectAddressesVisible
   );
@@ -325,6 +334,13 @@ export function ViewOptionsContextProvider({ children }: Props) {
     [devOptionsVisible]
   );
 
+  const setRenderAllModels = useCallback(
+    (value: boolean) => {
+      handleSetRenderAllModels(value);
+    },
+    [renderAllModels]
+  );
+
   const contextValue = useMemo<ViewOptions>(
     () => ({
       objectAddressesVisible,
@@ -351,7 +367,9 @@ export function ViewOptionsContextProvider({ children }: Props) {
       setThemeKey,
       toggleLightDarkTheme,
       devOptionsVisible,
-      setDevOptionsVisible
+      setDevOptionsVisible,
+      renderAllModels,
+      setRenderAllModels
     }),
     [
       objectAddressesVisible,
@@ -378,7 +396,9 @@ export function ViewOptionsContextProvider({ children }: Props) {
       setThemeKey,
       toggleLightDarkTheme,
       devOptionsVisible,
-      setDevOptionsVisible
+      setDevOptionsVisible,
+      renderAllModels,
+      setRenderAllModels
     ]
   );
 


### PR DESCRIPTION
Allows for exporting all models at once to gltf for Blender/Maya

Content in GLTF will render with layout similar to the following:
![image](https://github.com/rob2d/modnao/assets/1799905/a3be3a31-4b6a-45ac-a740-baf1ba09d003)

[closes #135]