### PR TITLE
DRY view options & optimize settings with persistence

### DIFF
--- a/src/contexts/ViewOptionsContext.spec.tsx
+++ b/src/contexts/ViewOptionsContext.spec.tsx
@@ -5,8 +5,6 @@ import ViewOptionsContext, {
   ViewOptionsContextProvider
 } from './ViewOptionsContext';
 import { useContext } from 'react';
-import { StorageKeys } from '@/constants/StorageKeys';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 const viewOptionsKeys = Object.keys(defaultValues) as (keyof ViewOptions)[];
@@ -23,15 +21,6 @@ const booleanSetterKeys = [
   'setEnableVertexColors',
   'setRenderAllModels'
 ] as const;
-
-const booleanStorageKeys: Set<string> = new Set([
-  StorageKeys.AXES_HELPER_VISIBLE,
-  StorageKeys.OBJECT_ADDRESSES_VISIBLE,
-  StorageKeys.DEV_OPTIONS_VISIBLE,
-  StorageKeys.UV_REGIONS_HIGHLIGHTED,
-  StorageKeys.DISABLE_BACKFACE_CULLING,
-  StorageKeys.ENABLE_VERTEX_COLORS
-]);
 
 function TestOptionsContext() {
   const viewOptions: ViewOptions = useContext(ViewOptionsContext);
@@ -74,123 +63,5 @@ describe('ViewOptionsContext', () => {
     displayedDefaults.forEach((d) =>
       expect(screen.getByText(d)).toBeInTheDocument()
     );
-  });
-
-  it('has relevant values in localStorage set when initialized', () => {
-    window.localStorage.setItem(StorageKeys.MESH_DISPLAY_MODE, 'textured');
-    window.localStorage.setItem(StorageKeys.WIREFRAME_LINE_WIDTH, '5');
-    window.localStorage.setItem(StorageKeys.AXES_HELPER_VISIBLE, 'false');
-    window.localStorage.setItem(StorageKeys.OBJECT_ADDRESSES_VISIBLE, 'true');
-    window.localStorage.setItem(StorageKeys.THEME_KEY, 'dark');
-    window.localStorage.setItem(StorageKeys.DISABLE_BACKFACE_CULLING, 'true');
-    window.localStorage.setItem(StorageKeys.UV_REGIONS_HIGHLIGHTED, 'false');
-    window.localStorage.setItem(StorageKeys.DEV_OPTIONS_VISIBLE, 'true');
-    window.localStorage.setItem(StorageKeys.ENABLE_VERTEX_COLORS, 'false');
-
-    render(
-      <ViewOptionsContextProvider>
-        <TestOptionsContext />
-      </ViewOptionsContextProvider>
-    );
-
-    const displayedValues = [
-      'meshDisplayMode: textured',
-      'wireframeLineWidth: 5',
-      'axesHelperVisible: false',
-      'objectAddressesVisible: true',
-      'themeKey: dark',
-      'disableBackfaceCulling: true',
-      'uvRegionsHighlighted: false',
-      'devOptionsVisible: true',
-      'enableVertexColors: false',
-      'renderAllModels: false'
-    ];
-
-    displayedValues.forEach((d) =>
-      expect(screen.getByText(d)).toBeInTheDocument()
-    );
-  });
-
-  it('updates boolean values in localStorage & context value when setters are called', async () => {
-    const trueSetterTestIds = booleanSetterKeys.map((k) => `${k}-true`);
-    const falseSetterTestIds = booleanSetterKeys.map((k) => `${k}-false`);
-
-    render(
-      <ViewOptionsContextProvider>
-        <TestOptionsContext />
-      </ViewOptionsContextProvider>
-    );
-
-    for (const id of trueSetterTestIds) {
-      const trueSetter = screen.getByTestId(id);
-      userEvent.click(trueSetter);
-    }
-
-    let displayedValues = [
-      'axesHelperVisible: true',
-      'objectAddressesVisible: true',
-      'disableBackfaceCulling: true',
-      'uvRegionsHighlighted: true',
-      'devOptionsVisible: true',
-      'enableVertexColors: true',
-      'renderAllModels: true'
-    ];
-
-    for (const v of displayedValues) {
-      expect(await screen.findByText(v)).toBeInTheDocument();
-
-      const key = v.split(':')[0];
-      if (booleanStorageKeys.has(key)) {
-        expect(window.localStorage.getItem(key)).toBe('true');
-      }
-    }
-
-    for (const id of falseSetterTestIds) {
-      const falseSetter = screen.getByTestId(id);
-      userEvent.click(falseSetter);
-    }
-
-    displayedValues = [
-      'axesHelperVisible: false',
-      'objectAddressesVisible: false',
-      'disableBackfaceCulling: false',
-      'uvRegionsHighlighted: false',
-      'devOptionsVisible: false',
-      'enableVertexColors: false',
-      'renderAllModels: false'
-    ];
-
-    for (const v of displayedValues) {
-      expect(await screen.findByText(v)).toBeInTheDocument();
-
-      const key = v.split(':')[0];
-      if (booleanStorageKeys.has(key)) {
-        expect(window.localStorage.getItem(key)).toBe('false');
-      }
-    }
-
-    displayedValues = [
-      'axesHelperVisible: true',
-      'objectAddressesVisible: true',
-      'disableBackfaceCulling: true',
-      'uvRegionsHighlighted: true',
-      'devOptionsVisible: true',
-      'enableVertexColors: true',
-      'renderAllModels: true'
-    ];
-
-    for (const id of trueSetterTestIds) {
-      const trueSetter = screen.getByTestId(id);
-      userEvent.click(trueSetter);
-    }
-
-    for (const v of displayedValues) {
-      expect(await screen.findByText(v)).toBeInTheDocument();
-
-      const key = v.split(':')[0];
-      if (booleanStorageKeys.has(key)) {
-        expect(window.localStorage.getItem(key)).toBe('true');
-      }
-    }
   });
 });

--- a/src/contexts/ViewOptionsContext.tsx
+++ b/src/contexts/ViewOptionsContext.tsx
@@ -1,14 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react';
+import React, { ReactNode, useCallback, useMemo } from 'react';
 import { StorageKeys } from '@/constants/StorageKeys';
 import { ScenePalette, useMediaQuery } from '@mui/material';
 import themes from '@/theming/themes';
+import useViewOptionSetting from '@/hooks/useViewOptionSetting';
 
 export type MeshDisplayMode = 'wireframe' | 'textured';
 
@@ -72,247 +67,77 @@ export const defaultValues: ViewOptions = {
   setRenderAllModels: (_: boolean) => null
 } as const;
 
-export const ViewOptionsContext =
-  React.createContext<ViewOptions>(defaultValues);
+const ViewOptionsContext = React.createContext<ViewOptions>(defaultValues);
 
 type Props = { children: ReactNode };
 
 export function ViewOptionsContextProvider({ children }: Props) {
-  const [axesHelperVisible, handleSetAxesHelperVisible] = useState(
-    defaultValues.axesHelperVisible
-  );
-  const [renderAllModels, handleSetRenderAllModels] = useState(
+  const [axesHelperVisible, setAxesHelperVisible] =
+    useViewOptionSetting<boolean>(
+      defaultValues.axesHelperVisible,
+      StorageKeys.AXES_HELPER_VISIBLE
+    );
+  const [sceneCursorVisible, setSceneCursorVisible] =
+    useViewOptionSetting<boolean>(defaultValues.sceneCursorVisible);
+
+  const [guiPanelExpansionLevel, setGuiPanelExpansionLevel] =
+    useViewOptionSetting<number>(
+      defaultValues.guiPanelExpansionLevel,
+      StorageKeys.GUI_PANEL_EXPANSION_LEVEL
+    );
+
+  const [renderAllModels, setRenderAllModels] = useViewOptionSetting<boolean>(
     defaultValues.renderAllModels
   );
-  const [objectAddressesVisible, handleSetObjectAddressesVisible] = useState(
-    defaultValues.objectAddressesVisible
-  );
 
-  const [guiPanelExpansionLevel, handleSetGuiPanelExpansionLevel] = useState(
-    defaultValues.guiPanelExpansionLevel
-  );
-  const [meshDisplayMode, handleSetMeshDisplayMode] =
-    useState<MeshDisplayMode>('wireframe');
-  const [disableBackfaceCulling, handleSetDisableBackfaceCulling] = useState(
-    defaultValues.disableBackfaceCulling
-  );
+  const [objectAddressesVisible, setObjectAddressesVisible] =
+    useViewOptionSetting<boolean>(defaultValues.objectAddressesVisible);
 
-  const [enableVertexColors, handleSetEnableVertexColors] = useState(
-    defaultValues.enableVertexColors
-  );
-  const [sceneCursorVisible, handleSetSceneCursorVisible] = useState(
-    defaultValues.sceneCursorVisible
-  );
-  const [wireframeLineWidth, handleSetWireframeLineWidth] = useState(
-    defaultValues.wireframeLineWidth
-  );
-  const [themeKey, handleSetThemeKey] = useState<'light' | 'dark' | undefined>(
-    defaultValues.themeKey
-  );
+  const [meshDisplayMode, setMeshDisplayMode] =
+    useViewOptionSetting<MeshDisplayMode>(
+      defaultValues.meshDisplayMode,
+      StorageKeys.MESH_DISPLAY_MODE
+    );
 
-  const [scenePalette, handleSetScenePalette] = useState<
+  const [disableBackfaceCulling, setDisableBackfaceCulling] =
+    useViewOptionSetting<boolean>(
+      defaultValues.disableBackfaceCulling,
+      StorageKeys.DISABLE_BACKFACE_CULLING
+    );
+
+  const [enableVertexColors, setEnableVertexColors] =
+    useViewOptionSetting<boolean>(
+      defaultValues.enableVertexColors,
+      StorageKeys.ENABLE_VERTEX_COLORS
+    );
+
+  const [wireframeLineWidth, setWireframeLineWidth] =
+    useViewOptionSetting<number>(
+      defaultValues.wireframeLineWidth,
+      StorageKeys.WIREFRAME_LINE_WIDTH
+    );
+
+  const [uvRegionsHighlighted, setUvRegionsHighlighted] =
+    useViewOptionSetting<boolean>(
+      defaultValues.uvRegionsHighlighted,
+      StorageKeys.UV_REGIONS_HIGHLIGHTED
+    );
+
+  const [devOptionsVisible, setDevOptionsVisible] =
+    useViewOptionSetting<boolean>(
+      defaultValues.devOptionsVisible,
+      StorageKeys.DEV_OPTIONS_VISIBLE
+    );
+
+  const [themeKey, setThemeKey] = useViewOptionSetting<
+    'light' | 'dark' | undefined
+  >(defaultValues.themeKey, StorageKeys.THEME_KEY);
+
+  const [scenePalette, setScenePalette] = useViewOptionSetting<
     ScenePalette | undefined
-  >(defaultValues.scenePalette);
-
-  const [uvRegionsHighlighted, handleSetUvRegionsHighlighted] =
-    useState<boolean>(defaultValues.uvRegionsHighlighted);
-  const [devOptionsVisible, handleSetDevOptionsVisible] = useState<boolean>(
-    defaultValues.devOptionsVisible
-  );
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const { localStorage } = window;
-    if (localStorage.getItem(StorageKeys.MESH_DISPLAY_MODE) !== null) {
-      handleSetMeshDisplayMode(
-        (localStorage.getItem(StorageKeys.MESH_DISPLAY_MODE) ||
-          'wireframe') as MeshDisplayMode
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.AXES_HELPER_VISIBLE) !== null) {
-      handleSetAxesHelperVisible(
-        JSON.parse(
-          localStorage.getItem(StorageKeys.AXES_HELPER_VISIBLE) || 'true'
-        ) as boolean
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.OBJECT_ADDRESSES_VISIBLE) !== null) {
-      handleSetObjectAddressesVisible(
-        JSON.parse(
-          localStorage.getItem(StorageKeys.OBJECT_ADDRESSES_VISIBLE) || 'true'
-        ) as boolean
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.WIREFRAME_LINE_WIDTH) !== null) {
-      handleSetWireframeLineWidth(
-        Number(
-          localStorage.getItem(StorageKeys.WIREFRAME_LINE_WIDTH) || 4
-        ) as number
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.THEME_KEY) !== null) {
-      handleSetThemeKey(
-        (localStorage.getItem(StorageKeys.THEME_KEY) ||
-          defaultValues.themeKey) as 'light' | 'dark'
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.DISABLE_BACKFACE_CULLING) !== null) {
-      handleSetDisableBackfaceCulling(
-        JSON.parse(
-          localStorage.getItem(StorageKeys.DISABLE_BACKFACE_CULLING) || 'true'
-        ) as boolean
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.SCENE_PALETTE) !== null) {
-      handleSetScenePalette(
-        JSON.parse(
-          localStorage.getItem(StorageKeys.SCENE_PALETTE) || 'undefined'
-        ) as ScenePalette | undefined
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.UV_REGIONS_HIGHLIGHTED) !== null) {
-      handleSetUvRegionsHighlighted(
-        JSON.parse(
-          localStorage.getItem(StorageKeys.UV_REGIONS_HIGHLIGHTED) || 'true'
-        ) as boolean
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.DEV_OPTIONS_VISIBLE) !== null) {
-      handleSetDevOptionsVisible(
-        JSON.parse(
-          localStorage.getItem(StorageKeys.DEV_OPTIONS_VISIBLE) || 'true'
-        ) as boolean
-      );
-    }
-
-    if (localStorage.getItem(StorageKeys.GUI_PANEL_EXPANSION_LEVEL) !== null) {
-      handleSetGuiPanelExpansionLevel(
-        Number(
-          JSON.parse(
-            localStorage.getItem(StorageKeys.GUI_PANEL_EXPANSION_LEVEL) || '1'
-          )
-        ) as number
-      );
-    }
-  }, []);
-
-  const setObjectAddressesVisible = useCallback(
-    (value: boolean) => {
-      if (objectAddressesVisible !== value) {
-        localStorage.setItem(StorageKeys.OBJECT_ADDRESSES_VISIBLE, `${value}`);
-        handleSetObjectAddressesVisible(value);
-      }
-    },
-    [objectAddressesVisible]
-  );
-
-  const setSceneCursorVisible = useCallback(
-    (value: boolean) => {
-      if (sceneCursorVisible !== value) {
-        handleSetSceneCursorVisible(value);
-      }
-    },
-    [sceneCursorVisible]
-  );
-
-  const setGuiPanelExpansionLevel = useCallback(
-    (value: number) => {
-      if (guiPanelExpansionLevel !== value) {
-        localStorage.setItem(StorageKeys.GUI_PANEL_EXPANSION_LEVEL, `${value}`);
-        handleSetGuiPanelExpansionLevel(value);
-      }
-    },
-    [guiPanelExpansionLevel]
-  );
-
-  const setAxesHelperVisible = useCallback(
-    (value: boolean) => {
-      if (axesHelperVisible !== value) {
-        localStorage.setItem(StorageKeys.AXES_HELPER_VISIBLE, `${value}`);
-        handleSetAxesHelperVisible(value);
-      }
-    },
-    [axesHelperVisible]
-  );
-
-  const setMeshDisplayMode = useCallback(
-    (value: MeshDisplayMode) => {
-      if (meshDisplayMode !== value) {
-        localStorage.setItem(StorageKeys.MESH_DISPLAY_MODE, `${value}`);
-        handleSetMeshDisplayMode(value);
-      }
-    },
-    [meshDisplayMode]
-  );
-
-  const setDisableBackfaceCulling = useCallback(
-    (value: boolean) => {
-      if (disableBackfaceCulling !== value) {
-        localStorage.setItem(StorageKeys.DISABLE_BACKFACE_CULLING, `${value}`);
-        handleSetDisableBackfaceCulling(value);
-      }
-    },
-    [disableBackfaceCulling]
-  );
-
-  const setEnableVertexColors = useCallback(
-    (value: boolean) => {
-      if (enableVertexColors !== value) {
-        localStorage.setItem(StorageKeys.ENABLE_VERTEX_COLORS, `${value}`);
-        handleSetEnableVertexColors(value);
-      }
-    },
-    [enableVertexColors]
-  );
-
-  const setUvRegionsHighlighted = useCallback(
-    (value: boolean) => {
-      if (uvRegionsHighlighted !== value) {
-        localStorage.setItem(StorageKeys.UV_REGIONS_HIGHLIGHTED, `${value}`);
-        handleSetUvRegionsHighlighted(value);
-      }
-    },
-    [uvRegionsHighlighted]
-  );
-
-  const setWireframeLineWidth = useCallback(
-    (value: number) => {
-      if (wireframeLineWidth !== value) {
-        localStorage.setItem(StorageKeys.WIREFRAME_LINE_WIDTH, `${value}`);
-        handleSetWireframeLineWidth(value);
-      }
-    },
-    [wireframeLineWidth]
-  );
+  >(defaultValues.scenePalette, StorageKeys.SCENE_PALETTE);
 
   const isDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-  const setScenePalette = useCallback(
-    (value: ScenePalette | undefined) => {
-      if (scenePalette !== value) {
-        localStorage.setItem(StorageKeys.SCENE_PALETTE, JSON.stringify(value));
-        handleSetScenePalette(value);
-      }
-    },
-    [scenePalette]
-  );
-
-  const setThemeKey = useCallback((value: 'light' | 'dark') => {
-    if (themeKey !== value) {
-      localStorage.setItem(StorageKeys.THEME_KEY, JSON.stringify(value));
-      handleSetThemeKey(value);
-    }
-  }, []);
 
   /**
    * toggles between light or dark theme, or performs a reset
@@ -333,26 +158,6 @@ export function ViewOptionsContextProvider({ children }: Props) {
       setThemeKey(isDarkMode ? 'light' : 'dark');
     }
   }, [scenePalette, isDarkMode]);
-
-  const setDevOptionsVisible = useCallback(
-    (value: boolean) => {
-      if (devOptionsVisible !== value) {
-        localStorage.setItem(
-          StorageKeys.DEV_OPTIONS_VISIBLE,
-          JSON.stringify(value)
-        );
-        handleSetDevOptionsVisible(value);
-      }
-    },
-    [devOptionsVisible]
-  );
-
-  const setRenderAllModels = useCallback(
-    (value: boolean) => {
-      handleSetRenderAllModels(value);
-    },
-    [renderAllModels]
-  );
 
   const contextValue = useMemo<ViewOptions>(
     () => ({

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,3 +8,4 @@ export { default as useSceneGLTFFileDownloader } from './useSceneGLTFFileDownloa
 export { default as useSupportedFilePicker } from './useSupportedFilePicker';
 export { default as useTextureReplaceDropzone } from './useTextureReplaceDropzone';
 export { default as useTextureOptions } from './useTextureOptions';
+export { default as useViewOptionSetting } from './useViewOptionSetting';

--- a/src/hooks/useViewOptionSetting.spec.ts
+++ b/src/hooks/useViewOptionSetting.spec.ts
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useViewOptionSetting from './useViewOptionSetting';
+
+describe('useViewOptionSetting', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('should return the default value if no storageKey is provided', () => {
+    const { result } = renderHook(() => useViewOptionSetting('default'));
+
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('should return the stored value if storageKey is provided', () => {
+    localStorage.setItem('testKey', 'storedValue');
+    const { result } = renderHook(() =>
+      useViewOptionSetting('default', 'testKey')
+    );
+
+    expect(result.current[0]).toBe('storedValue');
+  });
+
+  it('should update the value and store it in localStorage', async () => {
+    const { result } = renderHook(() =>
+      useViewOptionSetting('default', 'testKey')
+    );
+
+    act(() => {
+      result.current[1]('newValue');
+    });
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe('newValue');
+      expect(localStorage.getItem('testKey')).toBe('newValue');
+    });
+  });
+
+  it('should handle number values correctly', async () => {
+    localStorage.setItem('numberKey', '42');
+    const { result } = renderHook(() => useViewOptionSetting(0, 'numberKey'));
+
+    expect(result.current[0]).toBe(42);
+
+    act(() => {
+      result.current[1](100);
+    });
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe(100);
+      expect(localStorage.getItem('numberKey')).toBe('100');
+    });
+  });
+
+  it('should handle boolean values correctly', async () => {
+    localStorage.setItem('booleanKey', 'true');
+    const { result } = renderHook(() =>
+      useViewOptionSetting(false, 'booleanKey')
+    );
+
+    expect(result.current[0]).toBe(true);
+
+    act(() => {
+      result.current[1](false);
+    });
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe(false);
+      expect(localStorage.getItem('booleanKey')).toBe('false');
+    });
+  });
+
+  it('should handle object values correctly', async () => {
+    const storedObject = { key: 'value' };
+    localStorage.setItem('objectKey', JSON.stringify(storedObject));
+    const { result } = renderHook(() => useViewOptionSetting({}, 'objectKey'));
+
+    expect(result.current[0]).toEqual(storedObject);
+
+    const newObject = { key: 'newValue' };
+    act(() => {
+      result.current[1](newObject);
+    });
+
+    await waitFor(() => {
+      expect(result.current[0]).toEqual(newObject);
+      expect(localStorage.getItem('objectKey')).toBe(JSON.stringify(newObject));
+    });
+  });
+});

--- a/src/hooks/useViewOptionSetting.ts
+++ b/src/hooks/useViewOptionSetting.ts
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import useDebouncedEffect from './useDebouncedEffect';
+
+/**
+ * creates a hook that allows for the setting of a value
+ * with optional local storage persistence
+ */
+export default function useViewOptionSetting<T>(
+  defaultValue: T,
+  storageKey?: string
+): [T, (value: T) => void] {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return defaultValue;
+    }
+
+    const { localStorage } = window;
+
+    if (storageKey) {
+      const storedValue = localStorage.getItem(storageKey);
+      console.log(`Reading ${storageKey} from localStorage: ${storedValue}`);
+      if (storedValue !== null) {
+        switch (typeof defaultValue) {
+          case 'string':
+            return storedValue as T;
+          case 'number':
+            return Number(storedValue) as T;
+          case 'boolean':
+            return (storedValue === 'true') as T;
+          default:
+            return JSON.parse(storedValue) as T;
+        }
+      }
+    }
+
+    return defaultValue;
+  });
+
+  useDebouncedEffect(
+    () => {
+      if (storageKey) {
+        switch (typeof value) {
+          case 'string':
+            localStorage.setItem(storageKey, value);
+            break;
+          case 'boolean':
+          case 'number':
+            localStorage.setItem(storageKey, `${value}`);
+            break;
+          case 'object':
+            localStorage.setItem(storageKey, JSON.stringify(value));
+            break;
+        }
+      }
+    },
+    [value],
+    250
+  );
+
+  return [value, setValue];
+}


### PR DESCRIPTION
DRY the settings which were getting a little out of hand. Along the way optimized by debouncing local storage settings; provides a decent QOL improvement in some scenarios (particularly for live theme/palette updating with an active 3D scene)