### PR TITLE
export texture on web worker thread w/loading indicator

### DIFF
--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -2,13 +2,14 @@ import { useCallback, useContext } from 'react';
 import clsx from 'clsx';
 import GuiPanel from './panel/GuiPanel';
 import SceneView from './SceneView';
-import { Button, Paper, styled, Tooltip } from '@mui/material';
+import { Backdrop, Button, CircularProgress, Paper, styled, Tooltip, circularProgressClasses, useTheme } from '@mui/material';
 import Icon from '@mdi/react';
 import { mdiInformationOutline } from '@mdi/js';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
 import { AppDialog, AppInfo } from './dialogs';
 import {
   selectContentViewMode,
+  selectProcessingOverlayShown,
   showDialog,
   useAppDispatch,
   useAppSelector
@@ -108,12 +109,15 @@ const Styled = styled('main')(
 
 export default function MainView() {
   const { guiPanelExpansionLevel } = useContext(ViewOptionsContext);
+  const theme = useTheme();
   const dispatch = useAppDispatch();
   const onShowAppInfoDialog = useCallback(() => {
     dispatch(showDialog('app-info'));
   }, [dispatch]);
 
   const contentViewMode = useAppSelector(selectContentViewMode);
+  const processingOverlayShown = useAppSelector(selectProcessingOverlayShown);
+
   let mainScene;
 
   const guiPanelVisible =
@@ -173,6 +177,17 @@ export default function MainView() {
         </div>
         <GuiPanel />
         <AppDialog />
+        <Backdrop open={processingOverlayShown}>
+          <svg width={0} height={0}>
+            <defs>
+              <linearGradient id="my_gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" stopColor={theme.palette.primary.main} />
+                <stop offset="100%" stopColor={theme.palette.secondary.main} />
+              </linearGradient>
+            </defs>
+          </svg>
+          <CircularProgress size={64} sx={{ 'svg circle': { stroke: 'url(#my_gradient)' } }} />
+        </Backdrop>
       </Styled>
     </>
   );

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -2,7 +2,15 @@ import { useCallback, useContext } from 'react';
 import clsx from 'clsx';
 import GuiPanel from './panel/GuiPanel';
 import SceneView from './SceneView';
-import { Backdrop, Button, CircularProgress, Paper, styled, Tooltip, circularProgressClasses, useTheme } from '@mui/material';
+import {
+  Backdrop,
+  Button,
+  CircularProgress,
+  Paper,
+  styled,
+  Tooltip,
+  useTheme
+} from '@mui/material';
 import Icon from '@mdi/react';
 import { mdiInformationOutline } from '@mdi/js';
 import ViewOptionsContext from '@/contexts/ViewOptionsContext';
@@ -180,13 +188,22 @@ export default function MainView() {
         <Backdrop open={processingOverlayShown}>
           <svg width={0} height={0}>
             <defs>
-              <linearGradient id="my_gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" stopColor={theme.palette.primary.main} />
-                <stop offset="100%" stopColor={theme.palette.secondary.main} />
+              <linearGradient
+                id='my_gradient'
+                x1='0%'
+                y1='0%'
+                x2='0%'
+                y2='100%'
+              >
+                <stop offset='0%' stopColor={theme.palette.primary.main} />
+                <stop offset='100%' stopColor={theme.palette.secondary.main} />
               </linearGradient>
             </defs>
           </svg>
-          <CircularProgress size={64} sx={{ 'svg circle': { stroke: 'url(#my_gradient)' } }} />
+          <CircularProgress
+            size={64}
+            sx={{ 'svg circle': { stroke: 'url(#my_gradient)' } }}
+          />
         </Backdrop>
       </Styled>
     </>

--- a/src/store/modelData/modelDataSlice.ts
+++ b/src/store/modelData/modelDataSlice.ts
@@ -151,7 +151,6 @@ const modelDataSlice = createSlice({
       }
     );
 
-
     builder.addCase(
       loadCharacterPortraitsFile.pending,
       (state: ModelDataState) => {

--- a/src/store/modelData/modelDataSlice.ts
+++ b/src/store/modelData/modelDataSlice.ts
@@ -3,6 +3,7 @@ import { HYDRATE } from 'next-redux-wrapper';
 import { TextureImageBufferKeys } from '@/utils/textures/TextureImageBufferKeys';
 import { LoadTexturesResultPayload, ModelDataState } from './modelDataTypes';
 import {
+  downloadTextureFile,
   loadCharacterPortraitsFile,
   processAdjustedTextureHsl,
   processPolygonFile,
@@ -13,6 +14,7 @@ export const initialModelDataState: ModelDataState = {
   models: [],
   textureDefs: [],
   loadTexturesState: 'idle',
+  exportTextureFileState: 'idle',
   editedTextures: {},
   textureHistory: {},
   polygonFileName: undefined,
@@ -71,12 +73,6 @@ const modelDataSlice = createSlice({
     }
   },
   extraReducers: (builder) => {
-    builder.addCase(processPolygonFile.pending, (state: ModelDataState) => {
-      state.loadTexturesState = 'idle';
-    });
-    builder.addCase(processTextureFile.pending, (state: ModelDataState) => {
-      state.loadTexturesState = 'pending';
-    });
     builder.addCase(
       processPolygonFile.fulfilled,
       (
@@ -105,6 +101,29 @@ const modelDataSlice = createSlice({
       }
     );
 
+    builder.addCase(downloadTextureFile.pending, (state: ModelDataState) => {
+      state.exportTextureFileState = 'pending';
+    });
+
+    builder.addCase(downloadTextureFile.fulfilled, (state: ModelDataState) => {
+      state.exportTextureFileState = 'fulfilled';
+    });
+
+    builder.addCase(downloadTextureFile.rejected, (state: ModelDataState) => {
+      state.exportTextureFileState = 'rejected';
+    });
+
+    builder.addCase(processPolygonFile.pending, (state: ModelDataState) => {
+      state.loadTexturesState = 'idle';
+    });
+    builder.addCase(processTextureFile.pending, (state: ModelDataState) => {
+      state.loadTexturesState = 'pending';
+    });
+
+    builder.addCase(processTextureFile.rejected, (state: ModelDataState) => {
+      state.loadTexturesState = 'rejected';
+    });
+
     builder.addCase(
       processTextureFile.fulfilled,
       (
@@ -132,9 +151,6 @@ const modelDataSlice = createSlice({
       }
     );
 
-    builder.addCase(processTextureFile.rejected, (state: ModelDataState) => {
-      state.loadTexturesState = 'rejected';
-    });
 
     builder.addCase(
       loadCharacterPortraitsFile.pending,

--- a/src/store/modelData/modelDataTypes.ts
+++ b/src/store/modelData/modelDataTypes.ts
@@ -14,6 +14,12 @@ export type EditedTexture = {
   hsl: HslValues;
 };
 
+export interface ExportTextureFilePayload {
+  textureDefs: NLUITextureDef[];
+  textureFileType: TextureFileType;
+  textureBuffer: SharedArrayBuffer;
+  isLzssCompressed: boolean;
+}
 export interface LoadTexturesBasePayload {
   textureFileType: TextureFileType;
   resourceAttribs?: ResourceAttribs;

--- a/src/store/modelData/modelDataTypes.ts
+++ b/src/store/modelData/modelDataTypes.ts
@@ -14,12 +14,6 @@ export type EditedTexture = {
   hsl: HslValues;
 };
 
-export interface ExportTextureFilePayload {
-  textureDefs: NLUITextureDef[];
-  textureFileType: TextureFileType;
-  textureBuffer: SharedArrayBuffer;
-  isLzssCompressed: boolean;
-}
 export interface LoadTexturesBasePayload {
   textureFileType: TextureFileType;
   resourceAttribs?: ResourceAttribs;

--- a/src/store/modelData/modelDataTypes.ts
+++ b/src/store/modelData/modelDataTypes.ts
@@ -87,4 +87,5 @@ export interface ModelDataState {
   textureBufferKey?: string;
   polygonBufferKey?: string;
   loadTexturesState: AsyncState;
+  exportTextureFileState: AsyncState;
 }

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -251,3 +251,5 @@ export const selectObjectCount = createSelector(
     }
   }
 );
+
+export const selectProcessingOverlayShown = (state: AppState) => state.modelData.exportTextureFileState === 'pending';

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -252,4 +252,5 @@ export const selectObjectCount = createSelector(
   }
 );
 
-export const selectProcessingOverlayShown = (state: AppState) => state.modelData.exportTextureFileState === 'pending';
+export const selectProcessingOverlayShown = (state: AppState) =>
+  state.modelData.exportTextureFileState === 'pending';

--- a/src/theming/themes.ts
+++ b/src/theming/themes.ts
@@ -67,6 +67,13 @@ const themes = Object.fromEntries(
               alignItems: 'center'
             }
           }
+        },
+        MuiBackdrop: {
+          styleOverrides: {
+            root: {
+              backgroundColor: 'rgba(0, 0, 0, 0.75)'
+            }
+          }
         }
       },
       palette: {

--- a/src/utils/data/padBufferForAlignment.ts
+++ b/src/utils/data/padBufferForAlignment.ts
@@ -1,4 +1,4 @@
-export function padBufferForAlignment(
+export default function padBufferForAlignment(
   alignment: number,
   buffer: Buffer | Uint8Array,
   startLocation = 0

--- a/src/utils/textures/files/index.ts
+++ b/src/utils/textures/files/index.ts
@@ -1,5 +1,5 @@
 export { default as createB64ImgFromTextureDef } from './createB64ImgFromTextureDef';
-export { default as exportTextureFile } from './exportTextureFile';
+export { default as exportTextureFile } from '../../../workers/exportTextureFileWorker';
 export { default as getQuantizationOptions } from './getQuantizationOptions';
 export { default as processExportTexturePixels } from './processExportTexturePixels';
 export { default as textureFileTypeMap } from './textureFileTypeMap';

--- a/src/utils/textures/files/processExportTexturePixels.spec.ts
+++ b/src/utils/textures/files/processExportTexturePixels.spec.ts
@@ -11,7 +11,7 @@ it('should correctly process RGB565 pixel colors and write to the texture buffer
   const baseLocation = 0;
   const ramOffset = 0;
   const colorFormat: TextureColorFormat = 'RGB565';
-  const textureBuffer = Buffer.alloc(6);
+  const textureBuffer = new SharedArrayBuffer(6);
 
   processExportTexturePixels({
     pixelColors,
@@ -23,7 +23,6 @@ it('should correctly process RGB565 pixel colors and write to the texture buffer
     textureBuffer
   });
 
-  expect(textureBuffer).toEqual(
-    Buffer.from(new Uint8Array([6, 248, 224, 15, 0, 0]))
-  );
+  const uint8Array = new Uint8Array(textureBuffer);
+  expect(uint8Array).toEqual(new Uint8Array([6, 248, 224, 15, 0, 0]));
 });

--- a/src/utils/textures/files/processExportTexturePixels.ts
+++ b/src/utils/textures/files/processExportTexturePixels.ts
@@ -33,8 +33,9 @@ export default function processExportTexturePixels({
   baseLocation: number;
   ramOffset: number;
   colorFormat: TextureColorFormat;
-  textureBuffer: Buffer;
+  textureBuffer: SharedArrayBuffer;
 }) {
+  const buffer = new Uint8Array(textureBuffer);
   for (let y = 0; y < height; y++) {
     const yOffset = width * y;
     for (let offset = yOffset; offset < yOffset + width; offset++) {
@@ -51,8 +52,10 @@ export default function processExportTexturePixels({
       const conversionOp = conversionDict[colorFormat];
       const offsetWritten = baseLocation - ramOffset + offset * COLOR_SIZE;
 
-      if (offsetWritten + COLOR_SIZE < textureBuffer.length) {
-        textureBuffer.writeUInt16LE(conversionOp(color), offsetWritten);
+      if (offsetWritten + COLOR_SIZE < buffer.length) {
+        const convertedColor = conversionOp(color);
+        buffer[offsetWritten] = convertedColor & 0xff;
+        buffer[offsetWritten + 1] = (convertedColor >> 8) & 0xff;
       }
 
       if (colorOffset + 3 >= pixelColors.length) {

--- a/src/utils/threads/ClientThread.ts
+++ b/src/utils/threads/ClientThread.ts
@@ -58,6 +58,7 @@ export default class ClientThread {
       }
 
       thread.onmessage = (event: MessageEvent<{ result: TResult }>) => {
+        console.log('finished');
         resolve(event.data.result);
         thread.unallocate();
       };

--- a/src/workers/exportTextureDefRegionWorker.ts
+++ b/src/workers/exportTextureDefRegionWorker.ts
@@ -1,0 +1,42 @@
+import quanti from 'quanti';
+import { NLUITextureDef } from '@/types/NLAbstractions';
+import { TextureFileType } from '@/utils/textures/files/textureFileTypeMap';
+import processExportTexturePixels from '@/utils/textures/files/processExportTexturePixels';
+import getQuantizeOptions from '@/utils/textures/files/getQuantizationOptions';
+
+export type ExportTextureDefRegionWorkerPayload = {
+  textureDef: NLUITextureDef;
+  textureFileType: TextureFileType;
+  textureBuffer: SharedArrayBuffer;
+  pixelColors: SharedArrayBuffer;
+};
+
+export default async function exportTextureDefRegionWorker({
+  textureDef,
+  textureFileType,
+  textureBuffer,
+  pixelColors
+}: ExportTextureDefRegionWorkerPayload) {
+  const pixelColorsBuffer = new Uint8Array(pixelColors);
+  const { baseLocation, ramOffset, width, height, colorFormat } = textureDef;
+  const quantizeOptions = getQuantizeOptions(textureFileType, width);
+
+  if (quantizeOptions) {
+    const palette = quanti(pixelColorsBuffer, quantizeOptions.colors, 4);
+    if (quantizeOptions.dithering) {
+      palette.ditherProcess(pixelColorsBuffer, width);
+    } else {
+      palette.process(pixelColorsBuffer);
+    }
+  }
+
+  processExportTexturePixels({
+    pixelColors: pixelColorsBuffer,
+    width,
+    height,
+    baseLocation,
+    ramOffset,
+    colorFormat,
+    textureBuffer
+  });
+}

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -7,6 +7,7 @@ import loadTextureFileWorker, {
 import loadPolygonFileWorker, {
   LoadPolygonFileWorkerPayload
 } from './loadPolygonFileWorker';
+import { ExportTextureFilePayload } from '@/store';
 
 export type WorkerEvent =
   | {
@@ -20,6 +21,10 @@ export type WorkerEvent =
   | {
       type: 'adjustTextureHsl';
       payload: AdjustTextureHslWorkerPayload;
+    }
+  | {
+      type: 'exportTextureFile';
+      payload: ExportTextureFilePayload;
     };
 
 addEventListener('message', async ({ data }: MessageEvent<WorkerEvent>) => {

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -7,7 +7,12 @@ import loadTextureFileWorker, {
 import loadPolygonFileWorker, {
   LoadPolygonFileWorkerPayload
 } from './loadPolygonFileWorker';
-import { ExportTextureFilePayload } from '@/store';
+import exportTextureFileWorker, {
+  ExportTextureFileWorkerPayload
+} from './exportTextureFileWorker';
+import exportTextureDefRegionWorker, {
+  ExportTextureDefRegionWorkerPayload
+} from './exportTextureDefRegionWorker';
 
 export type WorkerEvent =
   | {
@@ -24,9 +29,12 @@ export type WorkerEvent =
     }
   | {
       type: 'exportTextureFile';
-      payload: ExportTextureFilePayload;
+      payload: ExportTextureFileWorkerPayload;
+    }
+  | {
+      type: 'exportTextureDefRegion';
+      payload: ExportTextureDefRegionWorkerPayload;
     };
-
 addEventListener('message', async ({ data }: MessageEvent<WorkerEvent>) => {
   const { type, payload } = data;
   switch (type) {
@@ -35,16 +43,31 @@ addEventListener('message', async ({ data }: MessageEvent<WorkerEvent>) => {
       postMessage({ type: 'loadPolygonFile', result });
       break;
     }
+
     case 'loadTextureFile': {
       const result = await loadTextureFileWorker(payload);
       postMessage({ type: 'loadTextureFile', result });
       break;
     }
+
     case 'adjustTextureHsl': {
       const result = await adjustTextureHslWorker(payload);
       postMessage({ type: 'adjustTextureHsl', result });
       break;
     }
+
+    case 'exportTextureFile': {
+      const result = await exportTextureFileWorker(payload);
+      postMessage({ type: 'exportTextureFile', result });
+      break;
+    }
+
+    case 'exportTextureDefRegion': {
+      const result = await exportTextureDefRegionWorker(payload);
+      postMessage({ type: 'exportTextureDefRegion', result });
+      break;
+    }
+
     default: {
       break;
     }


### PR DESCRIPTION
Closes #139

![export-texture-on-external-thread-export](https://github.com/user-attachments/assets/27657ef2-ae0d-4003-be6c-737d2b938e54)

[much more impactful on UX with PLFAC/VQ textures which runs 30+sec, but used a stage scene to demo for brevity sake]