### PR TITLE
initial CVS1 Pro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ModNao
 
-SEGA Dreamcast ROM Model Viewer/Editor for Marvel vs Capcom 2 and Capcom vs SNK 2 (with other games as a WIP); Interactively explore, edit and export textures directly to a ROM file (or just images to download quickly) in a user friendly and accessible fashion on a ROM directly in your web browser.
+SEGA Dreamcast ROM Model Viewer/Editor for Marvel vs Capcom 2, Capcom vs SNK 1 Pro, Capcom vs SNK 2 (with other games potentially supported later); Interactively explore, edit and export textures directly to a ROM file, or just images to download quickly, in a user friendly and accessible fashion on a ROM directly in your web browser!
 
 Visit https://modnao.vercel.app to check it out... nao.
 

--- a/src/components/dialogs/file-support-info/FileSupportInfo.tsx
+++ b/src/components/dialogs/file-support-info/FileSupportInfo.tsx
@@ -101,6 +101,20 @@ const rows = [
     notes: `Must be loaded with a corresponding POL.BIN file.`
   },
   {
+    title: 'Capcom vs SNK Pro',
+    filenameFormat: 'DM{NN}POL.BIN',
+    filenameExample: 'DM00POL.BIN',
+    description: 'Demo/menu model/polygons',
+    notes: `Corresponding textures are in similarly named TEX.BIN files.`
+  },
+  {
+    title: 'Capcom vs SNK Pro',
+    filenameFormat: 'DM{NN}TEX.BIN',
+    filenameExample: 'DM00TEX.BIN',
+    description: 'Demo/menu textures',
+    notes: `Must be loaded with a corresponding POL.BIN file.`
+  },
+  {
     title: 'Capcom vs SNK 2',
     filenameFormat: 'STG{NN}POL.BIN',
     filenameExample: 'STG02POL.BIN',

--- a/src/components/dialogs/file-support-info/FileSupportInfo.tsx
+++ b/src/components/dialogs/file-support-info/FileSupportInfo.tsx
@@ -87,6 +87,20 @@ const rows = [
     notes: ''
   },
   {
+    title: 'Capcom vs SNK Pro',
+    filenameFormat: 'STG{NN}POL.BIN',
+    filenameExample: 'STG02POL.BIN',
+    description: 'Stage model/polygons',
+    notes: `Corresponding textures are in similarly named TEX.BIN files.`
+  },
+  {
+    title: 'Capcom vs SNK Pro',
+    filenameFormat: 'STG{NN}TEX.BIN',
+    filenameExample: 'STG02TEX.BIN',
+    description: 'Stage textures',
+    notes: `Must be loaded with a corresponding POL.BIN file.`
+  },
+  {
     title: 'Capcom vs SNK 2',
     filenameFormat: 'STG{NN}POL.BIN',
     filenameExample: 'STG02POL.BIN',

--- a/src/components/panel/ModelFileImportButton.tsx
+++ b/src/components/panel/ModelFileImportButton.tsx
@@ -48,7 +48,7 @@ export default function ModelFileImportButton() {
     >
       <GuiPanelButton
         id='select-pol-or-tex-button'
-        tooltip='Select an MVC2, CVS1, or CVS2 STG POL.BIN and/or TEX.BIN files'
+        tooltip='Select MVC2, CVS1, or CVS2 POL.BIN and/or TEX.BIN files'
         onClick={openFileSelector}
       >
         Import Model/Texture

--- a/src/components/panel/ModelFileImportButton.tsx
+++ b/src/components/panel/ModelFileImportButton.tsx
@@ -48,7 +48,7 @@ export default function ModelFileImportButton() {
     >
       <GuiPanelButton
         id='select-pol-or-tex-button'
-        tooltip='Select an MVC2 or CVS2 STG POL.BIN and/or TEX.BIN files'
+        tooltip='Select an MVC2, CVS1, or CVS2 STG POL.BIN and/or TEX.BIN files'
         onClick={openFileSelector}
       >
         Import Model/Texture

--- a/src/constants/resource-mappings/cvs1MenuAttribMappings.ts
+++ b/src/constants/resource-mappings/cvs1MenuAttribMappings.ts
@@ -1,0 +1,138 @@
+import type { ResourceAttribs } from '@/types';
+
+const cvs1DemoResourceAttribs = {
+  game: 'CVS1Pro',
+  name: 'Demo Model File (unspecified)',
+  resourceType: 'cvs1-demo',
+  polygonMapped: true,
+  oobReferencable: false,
+  hasLzssTextureFile: true
+} satisfies Omit<ResourceAttribs, 'identifier' | 'filenamePattern'>;
+
+const cvs1MenuSources = [
+  {
+    textureDefsHash: '37d9fb1acd9cac80d6f786850fa6c3b4c4ca044e',
+    name: 'Demo Model 00',
+    identifier: 'DM00',
+    filenamePattern: '^DM00(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: 'e26c44c2c1d64b50f82f26a318bb9ff11be15a3f',
+    name: 'Demo Model 01',
+    identifier: 'DM01',
+    filenamePattern: '^DM01(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: 'b8af7110a4b3f52895dc0c9828431d77d0cffb93',
+    name: 'Demo Model 02',
+    identifier: 'DM02',
+    filenamePattern: '^DM02(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: '2ee10db010879f59ca5aa3455e95fc889d3706a4',
+    name: 'Demo Model 03',
+    identifier: 'DM03',
+    filenamePattern: '^DM03(.mn)?POL.BIN$',
+    hasLzssTextureFile: false
+  },
+  {
+    textureDefsHash: 'cfa1ad9b7a049d658c09fc747af6830c36b476e3',
+    name: 'Demo Model 04',
+    identifier: 'DM04',
+    filenamePattern: '^DM04(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: 'aab4fad2fbf430fb3fd5509cbb7bf066381a01e7',
+    name: 'Demo Model 05',
+    identifier: 'DM05',
+    filenamePattern: '^DM05(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: '332b71c86b1e016b67276968c4191eaadebadcd2',
+    name: 'Demo Model 06',
+    identifier: 'DM06',
+    filenamePattern: '^DM06(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: 'a9733269f854135cb450acefcaa67670a4601226',
+    name: 'Demo Model 07',
+    identifier: 'DM07',
+    filenamePattern: '^DM07(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: '5327708e5ecb2c549a8d1675e58d1576a3aea919',
+    name: 'Demo Model 08',
+    identifier: 'DM08',
+    filenamePattern: '^DM08(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: '12e8feca65c8089018ea0a4949e331278eeb7690',
+    name: 'Demo Model 09',
+    identifier: 'DM09',
+    filenamePattern: '^DM09(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: '3c66669c57920d07032420b6e11ed26511357756',
+    name: 'Demo Models 10-75/88-91',
+    identifier: 'DM10-DM75/DM88-DM91',
+    filenamePattern:
+      '^DM(1[0-9]|2[1235-9]|[3-6][0-9]|7[0-5]|8[89]|9[01])(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: '2e57122211578849a0e64f316fdc82a222085469',
+    name: 'Demo Models 20/24/92',
+    identifier: 'DM20/DM24/DM92',
+    filenamePattern: '^DM(20|24|92)(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: 'fa1610afca1439745d929b128065ce0b55f2714f',
+    name: 'Demo Model 76',
+    identifier: 'DM76',
+    filenamePattern: '^DM76(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: 'bbdab340fbb21d360ef80a620eacd7c55e6810bc',
+    name: 'Demo Model 77',
+    identifier: 'DM77',
+    filenamePattern: '^DM77(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: '8a2eebe2404e73936fea34587acdbeadbaa498c6',
+    name: 'Demo Model 78',
+    identifier: 'DM78',
+    filenamePattern: '^DM78(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: 'dda53329c0def9a81de4df2cb2decbcd22e3859f',
+    name: 'Demo Model 79',
+    identifier: 'DM79',
+    filenamePattern: '^DM79(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: '4922ab47fc64eef5ee2a30621733e3e6cfae4308',
+    name: 'Demo Model 80',
+    identifier: 'DM80',
+    filenamePattern: '^DM80(.mn)?POL.BIN$'
+  },
+  {
+    textureDefsHash: 'd8fe02eae09901a05cd38c659748b17aa3f8477c',
+    name: 'Demo Models 81-86',
+    identifier: 'DM81-DM86',
+    filenamePattern: '^DM8[1-6](.mn)?POL.BIN$'
+  }
+] as const;
+
+const cvs1MenuAttribMappings = Object.fromEntries(
+  cvs1MenuSources.map(
+    ({ textureDefsHash, ...fields }) =>
+      [
+        textureDefsHash,
+        {
+          ...cvs1DemoResourceAttribs,
+          ...fields
+        }
+      ] as const
+  )
+) satisfies Record<string, ResourceAttribs>;
+
+export default cvs1MenuAttribMappings;

--- a/src/constants/resourceAttribMappings.ts
+++ b/src/constants/resourceAttribMappings.ts
@@ -1,5 +1,6 @@
 import type { NLUITextureDef, ResourceAttribs, TextureFileType } from '@/types';
 import createTextureDef from '@/utils/textures/createTextureDef';
+import cvs1MenuAttribMappings from './resource-mappings/cvs1MenuAttribMappings';
 import cvs2MenuAttribMappings from './resource-mappings/cvs2MenuAttribMappings';
 
 const mvc2PlFacStructure: Partial<NLUITextureDef>[] = [
@@ -21,15 +22,6 @@ const cvs1StageResourceAttribs = {
   game: 'CVS1Pro',
   name: 'Stage File (unspecified)',
   resourceType: 'cvs1-stage',
-  polygonMapped: true,
-  oobReferencable: false,
-  hasLzssTextureFile: true
-} satisfies Omit<ResourceAttribs, 'identifier' | 'filenamePattern'>;
-
-const cvs1DemoResourceAttribs = {
-  game: 'CVS1Pro',
-  name: 'Demo Model File (unspecified)',
-  resourceType: 'cvs1-demo',
   polygonMapped: true,
   oobReferencable: false,
   hasLzssTextureFile: true
@@ -74,116 +66,7 @@ const resourceAttribMappings: Record<ResourceHashKey, ResourceAttribs> = {
     identifier: 'STG0C',
     filenamePattern: '^STG0C(.mn)?POL.BIN$'
   },
-  '37d9fb1acd9cac80d6f786850fa6c3b4c4ca044e': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 00',
-    identifier: 'DM00',
-    filenamePattern: '^DM00(.mn)?POL.BIN$'
-  },
-  e26c44c2c1d64b50f82f26a318bb9ff11be15a3f: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 01',
-    identifier: 'DM01',
-    filenamePattern: '^DM01(.mn)?POL.BIN$'
-  },
-  b8af7110a4b3f52895dc0c9828431d77d0cffb93: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 02',
-    identifier: 'DM02',
-    filenamePattern: '^DM02(.mn)?POL.BIN$'
-  },
-  '2ee10db010879f59ca5aa3455e95fc889d3706a4': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 03',
-    identifier: 'DM03',
-    filenamePattern: '^DM03(.mn)?POL.BIN$',
-    hasLzssTextureFile: false
-  },
-  cfa1ad9b7a049d658c09fc747af6830c36b476e3: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 04',
-    identifier: 'DM04',
-    filenamePattern: '^DM04(.mn)?POL.BIN$'
-  },
-  aab4fad2fbf430fb3fd5509cbb7bf066381a01e7: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 05',
-    identifier: 'DM05',
-    filenamePattern: '^DM05(.mn)?POL.BIN$'
-  },
-  '332b71c86b1e016b67276968c4191eaadebadcd2': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 06',
-    identifier: 'DM06',
-    filenamePattern: '^DM06(.mn)?POL.BIN$'
-  },
-  a9733269f854135cb450acefcaa67670a4601226: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 07',
-    identifier: 'DM07',
-    filenamePattern: '^DM07(.mn)?POL.BIN$'
-  },
-  '5327708e5ecb2c549a8d1675e58d1576a3aea919': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 08',
-    identifier: 'DM08',
-    filenamePattern: '^DM08(.mn)?POL.BIN$'
-  },
-  '12e8feca65c8089018ea0a4949e331278eeb7690': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 09',
-    identifier: 'DM09',
-    filenamePattern: '^DM09(.mn)?POL.BIN$'
-  },
-  '3c66669c57920d07032420b6e11ed26511357756': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Models 10-75/88-91',
-    identifier: 'DM10-DM75/DM88-DM91',
-    filenamePattern:
-      '^DM(1[0-9]|2[1235-9]|[3-6][0-9]|7[0-5]|8[89]|9[01])(.mn)?POL.BIN$'
-  },
-  '2e57122211578849a0e64f316fdc82a222085469': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Models 20/24/92',
-    identifier: 'DM20/DM24/DM92',
-    filenamePattern: '^DM(20|24|92)(.mn)?POL.BIN$'
-  },
-  fa1610afca1439745d929b128065ce0b55f2714f: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 76',
-    identifier: 'DM76',
-    filenamePattern: '^DM76(.mn)?POL.BIN$'
-  },
-  bbdab340fbb21d360ef80a620eacd7c55e6810bc: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 77',
-    identifier: 'DM77',
-    filenamePattern: '^DM77(.mn)?POL.BIN$'
-  },
-  '8a2eebe2404e73936fea34587acdbeadbaa498c6': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 78',
-    identifier: 'DM78',
-    filenamePattern: '^DM78(.mn)?POL.BIN$'
-  },
-  dda53329c0def9a81de4df2cb2decbcd22e3859f: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 79',
-    identifier: 'DM79',
-    filenamePattern: '^DM79(.mn)?POL.BIN$'
-  },
-  '4922ab47fc64eef5ee2a30621733e3e6cfae4308': {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Model 80',
-    identifier: 'DM80',
-    filenamePattern: '^DM80(.mn)?POL.BIN$'
-  },
-  d8fe02eae09901a05cd38c659748b17aa3f8477c: {
-    ...cvs1DemoResourceAttribs,
-    name: 'Demo Models 81-86',
-    identifier: 'DM81-DM86',
-    filenamePattern: '^DM8[1-6](.mn)?POL.BIN$'
-  },
+  ...cvs1MenuAttribMappings,
   'mvc2-demo-dm0a': {
     game: 'MVC2',
     name: 'Demo Model 0A',

--- a/src/constants/resourceAttribMappings.ts
+++ b/src/constants/resourceAttribMappings.ts
@@ -26,6 +26,15 @@ const cvs1StageResourceAttribs = {
   hasLzssTextureFile: true
 } satisfies Omit<ResourceAttribs, 'identifier' | 'filenamePattern'>;
 
+const cvs1DemoResourceAttribs = {
+  game: 'CVS1Pro',
+  name: 'Demo Model File (unspecified)',
+  resourceType: 'cvs1-demo',
+  polygonMapped: true,
+  oobReferencable: false,
+  hasLzssTextureFile: true
+} satisfies Omit<ResourceAttribs, 'identifier' | 'filenamePattern'>;
+
 type ResourceHashKey = TextureFileType | string;
 const resourceAttribMappings: Record<ResourceHashKey, ResourceAttribs> = {
   ...cvs2MenuAttribMappings,
@@ -64,6 +73,116 @@ const resourceAttribMappings: Record<ResourceHashKey, ResourceAttribs> = {
     name: 'Stage 0C',
     identifier: 'STG0C',
     filenamePattern: '^STG0C(.mn)?POL.BIN$'
+  },
+  '37d9fb1acd9cac80d6f786850fa6c3b4c4ca044e': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 00',
+    identifier: 'DM00',
+    filenamePattern: '^DM00(.mn)?POL.BIN$'
+  },
+  e26c44c2c1d64b50f82f26a318bb9ff11be15a3f: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 01',
+    identifier: 'DM01',
+    filenamePattern: '^DM01(.mn)?POL.BIN$'
+  },
+  b8af7110a4b3f52895dc0c9828431d77d0cffb93: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 02',
+    identifier: 'DM02',
+    filenamePattern: '^DM02(.mn)?POL.BIN$'
+  },
+  '2ee10db010879f59ca5aa3455e95fc889d3706a4': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 03',
+    identifier: 'DM03',
+    filenamePattern: '^DM03(.mn)?POL.BIN$',
+    hasLzssTextureFile: false
+  },
+  cfa1ad9b7a049d658c09fc747af6830c36b476e3: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 04',
+    identifier: 'DM04',
+    filenamePattern: '^DM04(.mn)?POL.BIN$'
+  },
+  aab4fad2fbf430fb3fd5509cbb7bf066381a01e7: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 05',
+    identifier: 'DM05',
+    filenamePattern: '^DM05(.mn)?POL.BIN$'
+  },
+  '332b71c86b1e016b67276968c4191eaadebadcd2': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 06',
+    identifier: 'DM06',
+    filenamePattern: '^DM06(.mn)?POL.BIN$'
+  },
+  a9733269f854135cb450acefcaa67670a4601226: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 07',
+    identifier: 'DM07',
+    filenamePattern: '^DM07(.mn)?POL.BIN$'
+  },
+  '5327708e5ecb2c549a8d1675e58d1576a3aea919': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 08',
+    identifier: 'DM08',
+    filenamePattern: '^DM08(.mn)?POL.BIN$'
+  },
+  '12e8feca65c8089018ea0a4949e331278eeb7690': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 09',
+    identifier: 'DM09',
+    filenamePattern: '^DM09(.mn)?POL.BIN$'
+  },
+  '3c66669c57920d07032420b6e11ed26511357756': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Models 10-75/88-91',
+    identifier: 'DM10-DM75/DM88-DM91',
+    filenamePattern:
+      '^DM(1[0-9]|2[1235-9]|[3-6][0-9]|7[0-5]|8[89]|9[01])(.mn)?POL.BIN$'
+  },
+  '2e57122211578849a0e64f316fdc82a222085469': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Models 20/24/92',
+    identifier: 'DM20/DM24/DM92',
+    filenamePattern: '^DM(20|24|92)(.mn)?POL.BIN$'
+  },
+  fa1610afca1439745d929b128065ce0b55f2714f: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 76',
+    identifier: 'DM76',
+    filenamePattern: '^DM76(.mn)?POL.BIN$'
+  },
+  bbdab340fbb21d360ef80a620eacd7c55e6810bc: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 77',
+    identifier: 'DM77',
+    filenamePattern: '^DM77(.mn)?POL.BIN$'
+  },
+  '8a2eebe2404e73936fea34587acdbeadbaa498c6': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 78',
+    identifier: 'DM78',
+    filenamePattern: '^DM78(.mn)?POL.BIN$'
+  },
+  dda53329c0def9a81de4df2cb2decbcd22e3859f: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 79',
+    identifier: 'DM79',
+    filenamePattern: '^DM79(.mn)?POL.BIN$'
+  },
+  '4922ab47fc64eef5ee2a30621733e3e6cfae4308': {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Model 80',
+    identifier: 'DM80',
+    filenamePattern: '^DM80(.mn)?POL.BIN$'
+  },
+  d8fe02eae09901a05cd38c659748b17aa3f8477c: {
+    ...cvs1DemoResourceAttribs,
+    name: 'Demo Models 81-86',
+    identifier: 'DM81-DM86',
+    filenamePattern: '^DM8[1-6](.mn)?POL.BIN$'
   },
   'mvc2-demo-dm0a': {
     game: 'MVC2',

--- a/src/constants/resourceAttribMappings.ts
+++ b/src/constants/resourceAttribMappings.ts
@@ -17,9 +17,54 @@ const fontTextureArgs: Partial<NLUITextureDef> = {
   colorFormatValue: 2
 };
 
+const cvs1StageResourceAttribs = {
+  game: 'CVS1Pro',
+  name: 'Stage File (unspecified)',
+  resourceType: 'cvs1-stage',
+  polygonMapped: true,
+  oobReferencable: false,
+  hasLzssTextureFile: true
+} satisfies Omit<ResourceAttribs, 'identifier' | 'filenamePattern'>;
+
 type ResourceHashKey = TextureFileType | string;
 const resourceAttribMappings: Record<ResourceHashKey, ResourceAttribs> = {
   ...cvs2MenuAttribMappings,
+  '6971c7f91ff9f0f83b771609451e49d7814b5388': {
+    ...cvs1StageResourceAttribs,
+    name: 'Stage 00/0B',
+    identifier: 'STG00/STG0B',
+    filenamePattern: '^STG(00|0B)(.mn)?POL.BIN$'
+  },
+  c914cac667b9d564479b256f378eb7bf95997ec3: {
+    ...cvs1StageResourceAttribs,
+    name: 'Stage 02',
+    identifier: 'STG02',
+    filenamePattern: '^STG02(.mn)?POL.BIN$'
+  },
+  '7a3438fef9b108f5e5c904c51e4b2b29d0be0bff': {
+    ...cvs1StageResourceAttribs,
+    name: 'Stage 04',
+    identifier: 'STG04',
+    filenamePattern: '^STG04(.mn)?POL.BIN$'
+  },
+  a3b52397da2e4011c12939fd4ff59432600434ed: {
+    ...cvs1StageResourceAttribs,
+    name: 'Stage 05',
+    identifier: 'STG05',
+    filenamePattern: '^STG05(.mn)?POL.BIN$'
+  },
+  '076811481292fdea66848bc344bdc9201df7df59': {
+    ...cvs1StageResourceAttribs,
+    name: 'Stage 07',
+    identifier: 'STG07',
+    filenamePattern: '^STG07(.mn)?POL.BIN$'
+  },
+  fd5ff139f281e7a016bb8ece18b70816d3928934: {
+    ...cvs1StageResourceAttribs,
+    name: 'Stage 0C',
+    identifier: 'STG0C',
+    filenamePattern: '^STG0C(.mn)?POL.BIN$'
+  },
   'mvc2-demo-dm0a': {
     game: 'MVC2',
     name: 'Demo Model 0A',

--- a/src/modules/model-data/modelDataThunks.ts
+++ b/src/modules/model-data/modelDataThunks.ts
@@ -299,9 +299,11 @@ export const processTextureFile = createAppAsyncThunk(
         : new Uint8Array(await file.arrayBuffer())
     );
 
-    const isDirectResourceLzssd = activeResourceAttribs.hasLzssTextureFile;
+    const usesLzssTextureFile = Boolean(
+      isLzssCompressed || activeResourceAttribs.hasLzssTextureFile
+    );
 
-    if (isLzssCompressed || isDirectResourceLzssd) {
+    if (usesLzssTextureFile) {
       const fBuffer = await file.arrayBuffer();
       const sharedBuffer = sharedBufferFrom(fBuffer);
       buffer = Buffer.from(new Uint8Array(decompressLzssBuffer(sharedBuffer)));
@@ -315,7 +317,7 @@ export const processTextureFile = createAppAsyncThunk(
       fileName: file.name,
       textureDefs,
       textureFileBuffer,
-      isLzssCompressed,
+      isLzssCompressed: usesLzssTextureFile,
       textureFileType,
       resourceAttribs: activeResourceAttribs
     });
@@ -349,7 +351,8 @@ export const processTextureFile = createAppAsyncThunk(
       textureDefs: updatedTextureDefs,
       textureFileType,
       fileName: file.name,
-      isLzssCompressed,
+      isLzssCompressed:
+        usesLzssTextureFile || Boolean(threadResult.isLzssCompressed),
       resourceAttribs: finalResourceAttribs
     };
   }

--- a/src/modules/model-data/modelDataThunks.ts
+++ b/src/modules/model-data/modelDataThunks.ts
@@ -317,9 +317,8 @@ export const processTextureFile = createAppAsyncThunk(
       fileName: file.name,
       textureDefs,
       textureFileBuffer,
-      isLzssCompressed: usesLzssTextureFile,
-      textureFileType,
-      resourceAttribs: activeResourceAttribs
+      oobReferenceable: activeResourceAttribs.oobReferencable,
+      isLzssCompressed: usesLzssTextureFile
     });
 
     const updatedTextureDefs = structuredClone(textureDefs);
@@ -344,8 +343,6 @@ export const processTextureFile = createAppAsyncThunk(
       threadResult.decompressedTextureBuffer
     );
 
-    const finalResourceAttribs = threadResult.resourceAttribs;
-
     return {
       textureBufferKey,
       textureDefs: updatedTextureDefs,
@@ -353,7 +350,7 @@ export const processTextureFile = createAppAsyncThunk(
       fileName: file.name,
       isLzssCompressed:
         usesLzssTextureFile || Boolean(threadResult.isLzssCompressed),
-      resourceAttribs: finalResourceAttribs
+      resourceAttribs: activeResourceAttribs
     };
   }
 );

--- a/src/types/ResourceAttribs.ts
+++ b/src/types/ResourceAttribs.ts
@@ -3,6 +3,7 @@ import { NLUITextureDef } from './NLAbstractions';
 
 type ResourceType =
   | 'mvc2-stage'
+  | 'cvs1-stage'
   | 'cvs2-stage'
   | 'cvs2-menu'
   | 'mvc2-menu'

--- a/src/types/ResourceAttribs.ts
+++ b/src/types/ResourceAttribs.ts
@@ -4,6 +4,7 @@ import { NLUITextureDef } from './NLAbstractions';
 type ResourceType =
   | 'mvc2-stage'
   | 'cvs1-stage'
+  | 'cvs1-demo'
   | 'cvs2-stage'
   | 'cvs2-menu'
   | 'mvc2-menu'

--- a/src/utils/resource-attribs/getResourceAttribs.spec.ts
+++ b/src/utils/resource-attribs/getResourceAttribs.spec.ts
@@ -1,0 +1,38 @@
+import getResourceAttribs from './getResourceAttribs';
+
+describe('getResourceAttribs', () => {
+  const cvs1StageFiles = [
+    ['6971c7f91ff9f0f83b771609451e49d7814b5388', 'STG00POL.BIN', 'STG00/STG0B'],
+    ['6971c7f91ff9f0f83b771609451e49d7814b5388', 'STG0BPOL.BIN', 'STG00/STG0B'],
+    ['c914cac667b9d564479b256f378eb7bf95997ec3', 'STG02POL.BIN', 'STG02'],
+    ['7a3438fef9b108f5e5c904c51e4b2b29d0be0bff', 'STG04POL.BIN', 'STG04'],
+    ['a3b52397da2e4011c12939fd4ff59432600434ed', 'STG05POL.BIN', 'STG05'],
+    ['076811481292fdea66848bc344bdc9201df7df59', 'STG07POL.BIN', 'STG07'],
+    ['fd5ff139f281e7a016bb8ece18b70816d3928934', 'STG0CPOL.BIN', 'STG0C']
+  ] as const;
+
+  it.each(cvs1StageFiles)(
+    'resolves %s and %s as a CVS1 stage resource',
+    (hash, fileName, identifier) => {
+      const resourceAttribs = getResourceAttribs(hash, fileName);
+
+      expect(resourceAttribs).toMatchObject({
+        game: 'CVS1Pro',
+        identifier,
+        resourceType: 'cvs1-stage',
+        polygonMapped: true,
+        hasLzssTextureFile: true
+      });
+    }
+  );
+
+  it('keeps unknown stage polygon files on the generic stage fallback', () => {
+    const resourceAttribs = getResourceAttribs('unknown', 'STG03POL.BIN');
+
+    expect(resourceAttribs).toMatchObject({
+      game: 'VS2',
+      resourceType: 'vs2-stage',
+      hasLzssTextureFile: false
+    });
+  });
+});

--- a/src/utils/resource-attribs/getResourceAttribs.spec.ts
+++ b/src/utils/resource-attribs/getResourceAttribs.spec.ts
@@ -11,6 +11,33 @@ describe('getResourceAttribs', () => {
     ['fd5ff139f281e7a016bb8ece18b70816d3928934', 'STG0CPOL.BIN', 'STG0C']
   ] as const;
 
+  const cvs1DemoFiles = [
+    ['37d9fb1acd9cac80d6f786850fa6c3b4c4ca044e', 'DM00POL.BIN', true],
+    ['e26c44c2c1d64b50f82f26a318bb9ff11be15a3f', 'DM01POL.BIN', true],
+    ['b8af7110a4b3f52895dc0c9828431d77d0cffb93', 'DM02POL.BIN', true],
+    ['2ee10db010879f59ca5aa3455e95fc889d3706a4', 'DM03POL.BIN', false],
+    ['cfa1ad9b7a049d658c09fc747af6830c36b476e3', 'DM04POL.BIN', true],
+    ['aab4fad2fbf430fb3fd5509cbb7bf066381a01e7', 'DM05POL.BIN', true],
+    ['332b71c86b1e016b67276968c4191eaadebadcd2', 'DM06POL.BIN', true],
+    ['a9733269f854135cb450acefcaa67670a4601226', 'DM07POL.BIN', true],
+    ['5327708e5ecb2c549a8d1675e58d1576a3aea919', 'DM08POL.BIN', true],
+    ['12e8feca65c8089018ea0a4949e331278eeb7690', 'DM09POL.BIN', true],
+    ['3c66669c57920d07032420b6e11ed26511357756', 'DM10POL.BIN', true],
+    ['3c66669c57920d07032420b6e11ed26511357756', 'DM75POL.BIN', true],
+    ['3c66669c57920d07032420b6e11ed26511357756', 'DM88POL.BIN', true],
+    ['3c66669c57920d07032420b6e11ed26511357756', 'DM91POL.BIN', true],
+    ['2e57122211578849a0e64f316fdc82a222085469', 'DM20POL.BIN', true],
+    ['2e57122211578849a0e64f316fdc82a222085469', 'DM24POL.BIN', true],
+    ['2e57122211578849a0e64f316fdc82a222085469', 'DM92POL.BIN', true],
+    ['fa1610afca1439745d929b128065ce0b55f2714f', 'DM76POL.BIN', true],
+    ['bbdab340fbb21d360ef80a620eacd7c55e6810bc', 'DM77POL.BIN', true],
+    ['8a2eebe2404e73936fea34587acdbeadbaa498c6', 'DM78POL.BIN', true],
+    ['dda53329c0def9a81de4df2cb2decbcd22e3859f', 'DM79POL.BIN', true],
+    ['4922ab47fc64eef5ee2a30621733e3e6cfae4308', 'DM80POL.BIN', true],
+    ['d8fe02eae09901a05cd38c659748b17aa3f8477c', 'DM81POL.BIN', true],
+    ['d8fe02eae09901a05cd38c659748b17aa3f8477c', 'DM86POL.BIN', true]
+  ] as const;
+
   it.each(cvs1StageFiles)(
     'resolves %s and %s as a CVS1 stage resource',
     (hash, fileName, identifier) => {
@@ -22,6 +49,20 @@ describe('getResourceAttribs', () => {
         resourceType: 'cvs1-stage',
         polygonMapped: true,
         hasLzssTextureFile: true
+      });
+    }
+  );
+
+  it.each(cvs1DemoFiles)(
+    'resolves %s and %s as a CVS1 demo resource',
+    (hash, fileName, hasLzssTextureFile) => {
+      const resourceAttribs = getResourceAttribs(hash, fileName);
+
+      expect(resourceAttribs).toMatchObject({
+        game: 'CVS1Pro',
+        resourceType: 'cvs1-demo',
+        polygonMapped: true,
+        hasLzssTextureFile
       });
     }
   );

--- a/src/workers/loadTextureFileWorker.ts
+++ b/src/workers/loadTextureFileWorker.ts
@@ -1,30 +1,26 @@
-import type {
-  NLUITextureDef,
-  ResourceAttribs,
-  TextureDataUrlType,
-  TextureFileType
-} from '@/types';
+import type { NLUITextureDef, TextureDataUrlType } from '@/types';
 import encodeZMortonPosition from '@/utils/textures/parse/encodeZMortonPosition';
 import decompressLzssBuffer from '@/utils/data/decompressLzssBuffer';
-import { LoadTexturesBasePayload } from '@/modules/model-data';
 import rgba8888TargetOps from '@/utils/color-conversions/rgba8888TargetOps';
-import resourceAttribMappings from '@/constants/resourceAttribMappings';
 import decompressVqBuffer from '@/utils/data/decompressVqBuffer';
-import { getTextureDefDataLength } from '@/utils/textures';
+import getTextureDefDataLength from '@/utils/textures/getTextureDefDataLength';
 import { VQ_TEXTURE_ENCODE_TYPE } from '@/utils/textures/VqFormatConstants';
+import type { LoadTexturesBasePayload } from '@/modules/model-data/modelDataTypes';
 
 export type LoadTextureFileWorkerResult = {
   texturePixelBuffers: SharedArrayBuffer[];
   decompressedTextureBuffer: SharedArrayBuffer;
   isLzssCompressed?: boolean;
-  resourceAttribs?: ResourceAttribs;
 };
 
-export type LoadTextureFileWorkerPayload = LoadTexturesBasePayload & {
+export type LoadTextureFileWorkerPayload = Pick<
+  LoadTexturesBasePayload,
+  'isLzssCompressed'
+> & {
   fileName: string;
   textureFileBuffer: SharedArrayBuffer;
   textureDefs: NLUITextureDef[];
-  textureFileType: TextureFileType;
+  oobReferenceable?: boolean;
 };
 
 const COLOR_SIZE = 2;
@@ -99,20 +95,14 @@ function createTexturePixelBuffers(
 export default function loadTextureFileWorker({
   textureFileBuffer,
   textureDefs,
-  textureFileType,
-  isLzssCompressed,
-  /** @TODO streamline architecture so initial
-   * call contains these attributes within the first call
-   */
-  resourceAttribs
+  oobReferenceable,
+  isLzssCompressed
 }: LoadTextureFileWorkerPayload) {
   let result: LoadTextureFileWorkerResult;
-  const resolvedResourceAttribs =
-    resourceAttribs ?? resourceAttribMappings[textureFileType];
-  const expectOobReferences = resolvedResourceAttribs.oobReferencable;
+  const expectOobReferences = oobReferenceable;
 
   try {
-    if (isLzssCompressed || resourceAttribs?.hasLzssTextureFile) {
+    if (isLzssCompressed) {
       new Error('Decompressed File');
     }
 
@@ -124,8 +114,7 @@ export default function loadTextureFileWorker({
 
     result = {
       texturePixelBuffers,
-      decompressedTextureBuffer: textureFileBuffer,
-      resourceAttribs: resolvedResourceAttribs
+      decompressedTextureBuffer: textureFileBuffer
     };
   } catch (error) {
     // if an overflow error occurs, this is an indicator that the
@@ -152,8 +141,7 @@ export default function loadTextureFileWorker({
     return {
       texturePixelBuffers,
       decompressedTextureBuffer,
-      isLzssCompressed: true,
-      resourceAttribs: resolvedResourceAttribs
+      isLzssCompressed: true
     };
   }
 

--- a/src/workers/loadTextureFileWorker.ts
+++ b/src/workers/loadTextureFileWorker.ts
@@ -16,6 +16,7 @@ import { VQ_TEXTURE_ENCODE_TYPE } from '@/utils/textures/VqFormatConstants';
 export type LoadTextureFileWorkerResult = {
   texturePixelBuffers: SharedArrayBuffer[];
   decompressedTextureBuffer: SharedArrayBuffer;
+  isLzssCompressed?: boolean;
   resourceAttribs?: ResourceAttribs;
 };
 


### PR DESCRIPTION
initial CVS1 Pro support (!).

<img width="1321" height="758" alt="image" src="https://github.com/user-attachments/assets/a63a5de0-5c93-44f7-bc8d-bd2c3d1d6104" />

Also, a bit of work simplifying the worker and debloating (accidentally imported @ module scope in a recent change)

closes #138 