### PR TITLE
Iterate on file support table UX

### DIFF
--- a/src/components/FilesSupportedButton.tsx
+++ b/src/components/FilesSupportedButton.tsx
@@ -11,7 +11,12 @@ export default function FilesSupportedButton({
 }) {
   const dispatch = useAppDispatch();
   const onShowFileSupportInfo = useCallback(() => {
-    dispatch(showDialog('file-support-info'));
+    dispatch(
+      showDialog({
+        type: 'file-support-info',
+        width: 'calc(100vw - 32px)'
+      })
+    );
   }, [dispatch]);
 
   return (

--- a/src/components/FilesSupportedButton.tsx
+++ b/src/components/FilesSupportedButton.tsx
@@ -14,7 +14,12 @@ export default function FilesSupportedButton({
     dispatch(
       showDialog({
         type: 'file-support-info',
-        width: 'calc(100vw - 32px)'
+        sx: {
+          '& .MuiDialog-paper': {
+            width: 'calc(100vw - 32px)',
+            maxWidth: 'calc(100vw - 32px)'
+          }
+        }
       })
     );
   }, [dispatch]);

--- a/src/components/dialogs/AppDialog.tsx
+++ b/src/components/dialogs/AppDialog.tsx
@@ -14,10 +14,10 @@ const Dialogs: Record<DialogType, FC> = {
 
 export default function AppDialog() {
   const dispatch = useAppDispatch();
-  const dialogType = useAppSelector((state) => state.dialogs.dialogShown);
-  const DialogComponent = dialogType ? Dialogs[dialogType] : null;
+  const { dialogShown, width } = useAppSelector((state) => state.dialogs);
+  const DialogComponent = dialogShown ? Dialogs[dialogShown] : null;
   const onClose = useCallback(() => {
-    switch (dialogType) {
+    switch (dialogShown) {
       // user must explicitly close dialog via content
       // within the dialog for the following types
       case 'replace-texture': {
@@ -28,15 +28,25 @@ export default function AppDialog() {
         break;
       }
     }
-  }, [dialogType]);
+  }, [dialogShown]);
 
   return (
     <Dialog
       onClose={onClose}
-      open={Boolean(dialogType)}
+      open={Boolean(dialogShown)}
       fullWidth={true}
-      maxWidth='xl'
-      sx={{ '& .MuiDialogContent-root': { display: 'flex' } }}
+      maxWidth={width ? false : 'xl'}
+      sx={{
+        '& .MuiDialogContent-root': { display: 'flex' },
+        ...(width
+          ? {
+              '& .MuiDialog-paper': {
+                width,
+                maxWidth: width
+              }
+            }
+          : {})
+      }}
     >
       <DialogContent data-testid='app-dialog'>
         {DialogComponent ? <DialogComponent /> : null}

--- a/src/components/dialogs/AppDialog.tsx
+++ b/src/components/dialogs/AppDialog.tsx
@@ -14,7 +14,7 @@ const Dialogs: Record<DialogType, FC> = {
 
 export default function AppDialog() {
   const dispatch = useAppDispatch();
-  const { dialogShown, width } = useAppSelector((state) => state.dialogs);
+  const { dialogShown, sx } = useAppSelector((state) => state.dialogs);
   const DialogComponent = dialogShown ? Dialogs[dialogShown] : null;
   const onClose = useCallback(() => {
     switch (dialogShown) {
@@ -35,17 +35,10 @@ export default function AppDialog() {
       onClose={onClose}
       open={Boolean(dialogShown)}
       fullWidth={true}
-      maxWidth={width ? false : 'xl'}
+      maxWidth={'xl'}
       sx={{
         '& .MuiDialogContent-root': { display: 'flex' },
-        ...(width
-          ? {
-              '& .MuiDialog-paper': {
-                width,
-                maxWidth: width
-              }
-            }
-          : {})
+        ...(sx ?? {})
       }}
     >
       <DialogContent data-testid='app-dialog'>

--- a/src/components/dialogs/file-support-info/FileSupportInfo.tsx
+++ b/src/components/dialogs/file-support-info/FileSupportInfo.tsx
@@ -3,11 +3,22 @@ import { DataGrid, GridCellParams, GridColDef } from '@mui/x-data-grid';
 import DialogSectionHeader from '../DialogSectionHeader';
 import clsx from 'clsx';
 
-const rows = [
+interface FileSupportEntry {
+  title: string;
+  filenameFormat: string;
+  filenameExample: string;
+  fileType: 'Polygon' | 'Texture';
+  description: string;
+  notes?: string;
+  hasIssues?: boolean;
+}
+
+const supportEntries: FileSupportEntry[] = [
   {
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'STG{NN}POL.BIN',
     filenameExample: 'STG01POL.BIN',
+    fileType: 'Polygon',
     description: 'Stage model/polygons',
     notes: 'Corresponding textures are in similarly named TEX.BIN files'
   },
@@ -15,6 +26,7 @@ const rows = [
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'STG{NN}TEX.BIN',
     filenameExample: 'STG01TEX.BIN',
+    fileType: 'Texture',
     description: 'Stage textures',
     notes: 'Must be loaded with a corresponding POL.BIN file.'
   },
@@ -22,6 +34,7 @@ const rows = [
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'DM{NN}POL.BIN',
     filenameExample: 'DM01POL.BIN',
+    fileType: 'Polygon',
     description: 'Demo/menu model/polygons',
     notes: 'Corresponding textures are in similarly named TEX.BIN files'
   },
@@ -29,6 +42,7 @@ const rows = [
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'DM{NN}TEX.BIN',
     filenameExample: 'DM01TEX.BIN',
+    fileType: 'Texture',
     description: 'Demo/menu texture',
     hasIssues: true,
     notes:
@@ -38,13 +52,14 @@ const rows = [
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'PL{NN}_WIN.BIN',
     filenameExample: 'PL1B_WIN.BIN',
-    description: 'Player win portrait texture',
-    notes: ''
+    fileType: 'Texture',
+    description: 'Player win portrait texture'
   },
   {
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'PL{NN}_FAC.BIN',
     filenameExample: 'PL0D_FAC.BIN',
+    fileType: 'Texture',
     description:
       'Player lifebars (both Japanese & US/International), super portrait and v.s. portrait',
     notes:
@@ -54,27 +69,28 @@ const rows = [
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'END(DC|NM)TEX.BIN',
     filenameExample: 'ENDDCTEX.BIN',
-    description: 'Game ending pictures and hi score name font.',
-    notes: ''
+    fileType: 'Texture',
+    description: 'Game ending pictures and hi score name font.'
   },
   {
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'FONT.BIN',
     filenameExample: 'FONT.BIN',
-    description: 'Font textures',
-    notes: ''
+    fileType: 'Texture',
+    description: 'Font textures'
   },
   {
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'SELSTG.BIN',
     filenameExample: 'SELSTG.BIN',
-    description: 'Stage select screen previews.',
-    notes: ''
+    fileType: 'Texture',
+    description: 'Stage select screen previews.'
   },
   {
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'SELTEX.BIN',
     filenameExample: 'SELTEX.BIN',
+    fileType: 'Texture',
     description: 'Stage select screen textures',
     notes:
       'Palette will be limited to fit within size limits (handled automatically on export).'
@@ -83,13 +99,14 @@ const rows = [
     title: 'Marvel vs Capcom 2',
     filenameFormat: 'SELVM(J|U).BIN',
     filenameExample: 'SELVMJ.BIN',
-    description: 'VMU selection screen textures',
-    notes: ''
+    fileType: 'Texture',
+    description: 'VMU selection screen textures'
   },
   {
     title: 'Capcom vs SNK Pro',
     filenameFormat: 'STG{NN}POL.BIN',
     filenameExample: 'STG02POL.BIN',
+    fileType: 'Polygon',
     description: 'Stage model/polygons',
     notes: `Corresponding textures are in similarly named TEX.BIN files.`
   },
@@ -97,6 +114,7 @@ const rows = [
     title: 'Capcom vs SNK Pro',
     filenameFormat: 'STG{NN}TEX.BIN',
     filenameExample: 'STG02TEX.BIN',
+    fileType: 'Texture',
     description: 'Stage textures',
     notes: `Must be loaded with a corresponding POL.BIN file.`
   },
@@ -104,6 +122,7 @@ const rows = [
     title: 'Capcom vs SNK Pro',
     filenameFormat: 'DM{NN}POL.BIN',
     filenameExample: 'DM00POL.BIN',
+    fileType: 'Polygon',
     description: 'Demo/menu model/polygons',
     notes: `Corresponding textures are in similarly named TEX.BIN files.`
   },
@@ -111,6 +130,7 @@ const rows = [
     title: 'Capcom vs SNK Pro',
     filenameFormat: 'DM{NN}TEX.BIN',
     filenameExample: 'DM00TEX.BIN',
+    fileType: 'Texture',
     description: 'Demo/menu textures',
     notes: `Must be loaded with a corresponding POL.BIN file.`
   },
@@ -118,6 +138,7 @@ const rows = [
     title: 'Capcom vs SNK 2',
     filenameFormat: 'STG{NN}POL.BIN',
     filenameExample: 'STG02POL.BIN',
+    fileType: 'Polygon',
     description: 'Stage model/polygons',
     notes: `Corresponding textures are in similarly named TEX.BIN files.`
   },
@@ -125,6 +146,7 @@ const rows = [
     title: 'Capcom vs SNK 2',
     filenameFormat: 'STG{NN}(E)TEX.BIN',
     filenameExample: 'STG02TEX.BIN',
+    fileType: 'Texture',
     description: 'Stage textures',
     notes: `Must be loaded with a corresponding POL.BIN file.`
   },
@@ -132,6 +154,7 @@ const rows = [
     title: 'Capcom vs SNK 2',
     filenameFormat: 'DC{NN}POL.BIN',
     filenameExample: 'DC26POL.BIN',
+    fileType: 'Polygon',
     description: 'Menu/Gui polygons/models',
     notes: `Corresponding textures are in similarly named TEX.BIN files.`
   },
@@ -139,32 +162,44 @@ const rows = [
     title: 'Capcom vs SNK 2',
     filenameFormat: 'DC(E){NN}TEX.BIN',
     filenameExample: 'DC02TEX.BIN',
+    fileType: 'Texture',
     description: 'Menu/Gui textures',
     notes: `Must be loaded with a corresponding POL.BIN file. Certain files are not able to load due to VQ sections, palette will be limited on export.`,
     hasIssues: true
   }
-].map((r, id) => ({ ...r, id }));
+];
 
-const redIssueCellClassName = (params: GridCellParams) =>
+const rows = supportEntries.map((row, id) => ({
+  ...row,
+  id
+}));
+
+const getIssuesCellClassName = (params: GridCellParams) =>
   clsx(params.row.hasIssues ? 'has-issues' : '');
 
-const columns: GridColDef[] = [
+const columns: GridColDef<FileSupportEntry>[] = [
   {
     field: 'title',
     headerName: 'Title',
     width: 200,
-    cellClassName: redIssueCellClassName
+    cellClassName: getIssuesCellClassName
   },
   {
     field: 'filenameFormat',
     headerName: 'Filename Format',
     width: 200,
-    cellClassName: redIssueCellClassName
+    cellClassName: getIssuesCellClassName
   },
   {
     field: 'filenameExample',
     headerName: 'Example',
     width: 150
+  },
+  {
+    field: 'fileType',
+    headerName: 'Type',
+    width: 120,
+    cellClassName: getIssuesCellClassName
   },
   {
     field: 'description',
@@ -176,7 +211,7 @@ const columns: GridColDef[] = [
     headerName: 'Notes',
     sortable: false,
     width: 400,
-    cellClassName: redIssueCellClassName
+    cellClassName: getIssuesCellClassName
   }
 ];
 

--- a/src/components/dialogs/file-support-info/FileSupportInfo.tsx
+++ b/src/components/dialogs/file-support-info/FileSupportInfo.tsx
@@ -177,47 +177,53 @@ const rows = supportEntries.map((row, id) => ({
 const getIssuesCellClassName = (params: GridCellParams) =>
   clsx(params.row.hasIssues ? 'has-issues' : '');
 
-const columns: GridColDef<FileSupportEntry>[] = [
-  {
-    field: 'title',
-    headerName: 'Title',
-    width: 200,
-    cellClassName: getIssuesCellClassName
-  },
-  {
-    field: 'filenameFormat',
-    headerName: 'Filename Format',
-    width: 200,
-    cellClassName: getIssuesCellClassName
-  },
-  {
-    field: 'filenameExample',
-    headerName: 'Example',
-    width: 150
-  },
-  {
-    field: 'fileType',
-    headerName: 'Type',
-    width: 98,
-    cellClassName: getIssuesCellClassName
-  },
-  {
-    field: 'description',
-    headerName: 'Description',
-    width: 320
-  },
-  {
-    field: 'notes',
-    headerName: 'Notes',
-    sortable: false,
-    width: 400,
-    cellClassName: getIssuesCellClassName
-  }
-];
-
 const GET_AUTO_ROW_HEIGHT = () => 'auto' as const;
 
 export default function FileSupportInfo() {
+  const columns: GridColDef<FileSupportEntry>[] = [
+    {
+      field: 'title',
+      headerName: 'Title',
+      cellClassName: getIssuesCellClassName,
+      flex: 1.1,
+      minWidth: 200
+    },
+    {
+      field: 'filenameFormat',
+      headerName: 'Filename Format',
+      cellClassName: getIssuesCellClassName,
+      flex: 1.2,
+      minWidth: 200
+    },
+    {
+      field: 'filenameExample',
+      headerName: 'Example',
+      flex: 0.9,
+      minWidth: 150
+    },
+    {
+      field: 'fileType',
+      headerName: 'Type',
+      cellClassName: getIssuesCellClassName,
+      flex: 0.7,
+      minWidth: 98
+    },
+    {
+      field: 'description',
+      headerName: 'Description',
+      flex: 1.5,
+      minWidth: 320
+    },
+    {
+      field: 'notes',
+      headerName: 'Notes',
+      sortable: false,
+      cellClassName: getIssuesCellClassName,
+      flex: 2,
+      minWidth: 400
+    }
+  ];
+
   return (
     <Box
       sx={{

--- a/src/components/dialogs/file-support-info/FileSupportInfo.tsx
+++ b/src/components/dialogs/file-support-info/FileSupportInfo.tsx
@@ -198,13 +198,13 @@ const columns: GridColDef<FileSupportEntry>[] = [
   {
     field: 'fileType',
     headerName: 'Type',
-    width: 120,
+    width: 98,
     cellClassName: getIssuesCellClassName
   },
   {
     field: 'description',
     headerName: 'Description',
-    width: 350
+    width: 320
   },
   {
     field: 'notes',

--- a/src/modules/dialogs/dialogsSlice.ts
+++ b/src/modules/dialogs/dialogsSlice.ts
@@ -3,8 +3,14 @@ import { HYDRATE } from 'next-redux-wrapper';
 
 export type DialogType = 'app-info' | 'replace-texture' | 'file-support-info';
 
+export interface ShowDialogPayload {
+  type: DialogType;
+  width?: string;
+}
+
 export interface DialogsState {
   dialogShown?: DialogType;
+  width?: string;
 }
 
 export const initialDialogsState: DialogsState = {
@@ -15,12 +21,21 @@ const dialogsSlice = createSlice({
   name: 'dialogs',
   initialState: initialDialogsState,
   reducers: {
-    showDialog(state, action: { payload: DialogType }) {
-      state.dialogShown = action.payload;
+    showDialog(state, action: { payload: DialogType | ShowDialogPayload }) {
+      if (typeof action.payload === 'string') {
+        state.dialogShown = action.payload;
+        state.width = undefined;
+
+        return;
+      }
+
+      state.dialogShown = action.payload.type;
+      state.width = action.payload.width;
     },
 
     closeDialog(state) {
       state.dialogShown = undefined;
+      state.width = undefined;
     }
   },
   extraReducers: (builder) => {

--- a/src/modules/dialogs/dialogsSlice.ts
+++ b/src/modules/dialogs/dialogsSlice.ts
@@ -1,16 +1,19 @@
 import { createSlice, UnknownAction } from '@reduxjs/toolkit';
+import type { Theme } from '@mui/material';
+import type { SystemStyleObject } from '@mui/system';
+import { castDraft } from 'immer';
 import { HYDRATE } from 'next-redux-wrapper';
 
 export type DialogType = 'app-info' | 'replace-texture' | 'file-support-info';
 
 export interface ShowDialogPayload {
   type: DialogType;
-  width?: string;
+  sx?: SystemStyleObject<Theme>;
 }
 
 export interface DialogsState {
   dialogShown?: DialogType;
-  width?: string;
+  sx?: SystemStyleObject<Theme>;
 }
 
 export const initialDialogsState: DialogsState = {
@@ -21,21 +24,26 @@ const dialogsSlice = createSlice({
   name: 'dialogs',
   initialState: initialDialogsState,
   reducers: {
-    showDialog(state, action: { payload: DialogType | ShowDialogPayload }) {
-      if (typeof action.payload === 'string') {
-        state.dialogShown = action.payload;
-        state.width = undefined;
+    showDialog(
+      state,
+      { payload }: { payload: DialogType | ShowDialogPayload }
+    ) {
+      if (typeof payload === 'string') {
+        state.dialogShown = payload;
+        state.sx = undefined;
 
         return;
       }
 
-      state.dialogShown = action.payload.type;
-      state.width = action.payload.width;
+      const { type, sx } = payload;
+
+      state.dialogShown = type;
+      state.sx = sx ? castDraft(sx) : undefined;
     },
 
     closeDialog(state) {
       state.dialogShown = undefined;
-      state.width = undefined;
+      state.sx = undefined;
     }
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
Now that there are 3 games supported by the app, it is a good time to revise the file support table view:
- dialog is naturally responsive in larger views + better use of space
- new column for "file type" to indicate/quickly filter and sort whether it's polygons or textures being contained
- DX improvements via TS annotations and minor code cleanup
- launched dialogs can be optionally styled