### PR TITLE
model nav via search

### DIFF
--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -11,6 +11,7 @@ import {
 import HelpCenterIcon from '@mui/icons-material/HelpCenter';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import VideocamIcon from '@mui/icons-material/Videocam';
+import SearchIcon from '@mui/icons-material/Search';
 import SceneOptionsContext from '@/contexts/SceneOptionsContext';
 import { AppDialog, AppInfo } from './dialogs';
 import { showDialog } from '@/modules/dialogs';
@@ -123,7 +124,24 @@ export default function MainView() {
           }}
         >
           {mainScene}
-          {contentViewMode === 'welcome' ? undefined : (
+          {contentViewMode !== 'polygons' ? null : (
+            <IconButton
+              onClick={onShowBrowsedObjectHints}
+              sx={(theme) => ({
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                mr: 2,
+                mt: 1,
+                '& svg': {
+                  ...theme.mixins.sceneIconMixin
+                }
+              })}
+            >
+              <SearchIcon fontSize='medium' />
+            </IconButton>
+          )}
+          {contentViewMode !== 'polygons' ? null : (
             <>
               {!showBrowsedObjectHintsButtonVisible ? null : (
                 <Box

--- a/src/components/ResourceNavigator.tsx
+++ b/src/components/ResourceNavigator.tsx
@@ -2,6 +2,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import gameNameMap from '@/constants/gameNameMap';
 import resourceAttribMappings from '@/constants/resourceAttribMappings';
 import resourceTypeNameMap from '@/constants/resourceTypeNameMap';
+import { selectPolygonFileName, selectTextureFileName } from '@/selectors';
+import { useAppSelector } from '@/storeTypings';
 import type { ResourceAttribs } from '@/types';
 import {
   Autocomplete,
@@ -10,10 +12,11 @@ import {
   InputAdornment,
   Popper,
   PopperProps,
+  SxProps,
   TextField,
   Typography
 } from '@mui/material';
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 interface ResourceSearchOptionBase {
   id: string;
@@ -24,6 +27,8 @@ interface ResourceSearchOptionBase {
   identifier: string;
   filenamePattern: string;
   displayFilenamePattern: string;
+  textureDefsHash?: string;
+  textureFileType?: ResourceAttribs['textureFileType'];
   treeDepth: number;
   label: string;
   searchText: string;
@@ -45,6 +50,13 @@ interface ResourceModelSearchOption extends ResourceSearchOptionBase {
 type ResourceSearchOption =
   | ResourceMappingSearchOption
   | ResourceModelSearchOption;
+
+export type ResourceNavigatorOption = ResourceSearchOption;
+
+interface ResourceSearchInputState {
+  resetKey: string;
+  value: string;
+}
 
 const formatFilenamePattern = (filenamePattern: string) =>
   filenamePattern
@@ -74,11 +86,35 @@ function ResourceSearchPopper(props: PopperProps) {
   );
 }
 
+const getDisplayFilenamePattern = (attribs: ResourceAttribs) => {
+  const displayFilenamePattern = formatFilenamePattern(attribs.filenamePattern);
+
+  if (!/POL\.BIN$/i.test(attribs.filenamePattern)) {
+    return displayFilenamePattern;
+  }
+
+  const textureAttribs = attribs.textureFileType
+    ? resourceAttribMappings[attribs.textureFileType]
+    : Object.values(resourceAttribMappings).find(
+        (candidate) =>
+          candidate !== attribs &&
+          candidate.game === attribs.game &&
+          candidate.resourceType === attribs.resourceType &&
+          candidate.name === attribs.name &&
+          candidate.identifier === attribs.identifier &&
+          /TEX(?:\(.mn\)\?)?\.BIN\$/i.test(candidate.filenamePattern)
+      );
+
+  if (!textureAttribs) {
+    return displayFilenamePattern;
+  }
+
+  return `${displayFilenamePattern}, ${formatFilenamePattern(textureAttribs.filenamePattern)}`;
+};
+
 const resourceSearchOptions = Object.entries(resourceAttribMappings)
   .flatMap(([resourceKey, attribs]): ResourceSearchOption[] => {
-    const displayFilenamePattern = formatFilenamePattern(
-      attribs.filenamePattern
-    );
+    const displayFilenamePattern = getDisplayFilenamePattern(attribs);
     const resourceSearchText = [
       resourceKey,
       attribs.game,
@@ -102,6 +138,8 @@ const resourceSearchOptions = Object.entries(resourceAttribMappings)
       identifier: attribs.identifier,
       filenamePattern: attribs.filenamePattern,
       displayFilenamePattern,
+      textureDefsHash: attribs.textureDefsHash,
+      textureFileType: attribs.textureFileType,
       treeDepth: 1,
       label: attribs.name,
       searchText: resourceSearchText
@@ -132,6 +170,8 @@ const resourceSearchOptions = Object.entries(resourceAttribMappings)
             identifier: attribs.identifier,
             filenamePattern: attribs.filenamePattern,
             displayFilenamePattern,
+            textureDefsHash: attribs.textureDefsHash,
+            textureFileType: attribs.textureFileType,
             treeDepth: 2,
             modelIndex,
             modelDescription: modelHint.description,
@@ -198,19 +238,107 @@ const filterResourceSearchOptions = (
   });
 };
 
-export default function SearchForFiles() {
+const scopedResourceAttribKeys = [
+  'game',
+  'name',
+  'resourceType',
+  'identifier',
+  'filenamePattern',
+  'textureDefsHash',
+  'textureFileType'
+] as const satisfies ReadonlyArray<keyof ResourceAttribs>;
+
+const getScopedResourceKey = (scope: ResourceAttribs) =>
+  Object.entries(resourceAttribMappings).find(
+    ([, attribs]) =>
+      attribs === scope ||
+      scopedResourceAttribKeys.every((key) => attribs[key] === scope[key])
+  )?.[0];
+
+interface ResourceNavigatorProps {
+  includeSourceResourceOption?: boolean;
+  label?: string;
+  onSelectOption?: (option: ResourceNavigatorOption) => boolean;
+  scope?: ResourceAttribs;
+  sx?: SxProps;
+}
+
+export default function ResourceNavigator({
+  includeSourceResourceOption = true,
+  label = 'Find supported resources',
+  onSelectOption,
+  scope,
+  sx
+}: ResourceNavigatorProps) {
+  const polygonFileName = useAppSelector(selectPolygonFileName);
+  const textureFileName = useAppSelector(selectTextureFileName);
+  const resourceSearchInputResetKey = `${polygonFileName ?? ''}:${textureFileName ?? ''}`;
   const [isResourceSearchOpen, setIsResourceSearchOpen] = useState(false);
-  const [resourceSearchInput, setResourceSearchInput] = useState('');
-  const visibleResourceSearchParentKeys = new Set(
-    filterResourceSearchOptions(resourceSearchOptions, {
-      inputValue: resourceSearchInput
-    })
-      .filter((option) => option.kind === 'resource')
-      .map((option) => option.resourceKey)
+  const [resourceSearchInputState, setResourceSearchInputState] =
+    useState<ResourceSearchInputState>({
+      resetKey: resourceSearchInputResetKey,
+      value: ''
+    });
+  const resourceSearchInput =
+    resourceSearchInputState.resetKey === resourceSearchInputResetKey
+      ? resourceSearchInputState.value
+      : '';
+
+  const scopedResourceKey = useMemo(
+    () => (!scope ? undefined : getScopedResourceKey(scope)),
+    [scope]
+  );
+
+  const scopedResourceSearchOptions = useMemo(
+    () =>
+      !scopedResourceKey
+        ? resourceSearchOptions
+        : resourceSearchOptions.filter(
+            (option) => option.resourceKey === scopedResourceKey
+          ),
+    [scopedResourceKey]
+  );
+
+  const visibleResourceSearchOptions = useMemo(
+    () =>
+      includeSourceResourceOption
+        ? scopedResourceSearchOptions
+        : scopedResourceSearchOptions.filter(
+            (option) => option.kind === 'model'
+          ),
+    [includeSourceResourceOption, scopedResourceSearchOptions]
+  );
+
+  const visibleResourceSearchParentKeys = useMemo(
+    () =>
+      new Set(
+        filterResourceSearchOptions(visibleResourceSearchOptions, {
+          inputValue: resourceSearchInput
+        })
+          .filter((option) => option.kind === 'resource')
+          .map((option) => option.resourceKey)
+      ),
+    [resourceSearchInput, visibleResourceSearchOptions]
+  );
+
+  const onSelectResourceSearchOption = useCallback(
+    (_event: React.SyntheticEvent, option: ResourceSearchOption | null) => {
+      if (!option) {
+        return;
+      }
+
+      const didNavigate = onSelectOption?.(option) ?? false;
+
+      setResourceSearchInputState({
+        resetKey: resourceSearchInputResetKey,
+        value: didNavigate ? '' : option.displayFilenamePattern
+      });
+    },
+    [onSelectOption, resourceSearchInputResetKey]
   );
 
   return (
-    <Box sx={{ position: 'relative', width: '100%' }}>
+    <Box sx={{ position: 'relative', width: '100%', ...sx }}>
       <Box
         aria-hidden
         sx={{
@@ -236,6 +364,7 @@ export default function SearchForFiles() {
       >
         <Autocomplete<ResourceSearchOption>
           size='small'
+          blurOnSelect
           clearOnBlur={false}
           filterOptions={filterResourceSearchOptions}
           getOptionKey={(option) => option.id}
@@ -243,17 +372,22 @@ export default function SearchForFiles() {
           groupBy={(option) => gameNameMap[option.game]}
           inputValue={resourceSearchInput}
           isOptionEqualToValue={(option, value) => option.id === value.id}
+          onChange={onSelectResourceSearchOption}
           onClose={() => setIsResourceSearchOpen(false)}
           onInputChange={(_event, value, reason) => {
-            if (reason === 'blur') {
+            if (reason === 'blur' || reason === 'reset') {
               return;
             }
 
-            setResourceSearchInput(value);
+            setResourceSearchInputState({
+              resetKey: resourceSearchInputResetKey,
+              value
+            });
           }}
           onOpen={() => setIsResourceSearchOpen(true)}
           openOnFocus
-          options={resourceSearchOptions}
+          options={visibleResourceSearchOptions}
+          value={null}
           slots={{
             popper: ResourceSearchPopper
           }}
@@ -413,14 +547,14 @@ export default function SearchForFiles() {
               variant='outlined'
               {...params}
               fullWidth
-              label='Find supported resources'
+              label={label}
               sx={{ width: '100%' }}
               slotProps={{
                 input: {
                   ...params.InputProps,
                   startAdornment: (
                     <>
-                      <InputAdornment position='start'>
+                      <InputAdornment position='start' sx={{ mr: 0.5 }}>
                         <SearchIcon
                           fontSize='small'
                           sx={{ color: 'var(--mui-palette-text-secondary)' }}
@@ -429,7 +563,12 @@ export default function SearchForFiles() {
                       {params.InputProps.startAdornment}
                     </>
                   ),
-                  sx: { width: '100%' }
+                  sx: {
+                    width: '100%',
+                    '& .MuiAutocomplete-input': {
+                      pl: 0
+                    }
+                  }
                 }
               }}
             />

--- a/src/components/panel/FileImportArea.tsx
+++ b/src/components/panel/FileImportArea.tsx
@@ -1,9 +1,8 @@
-import SearchIcon from '@mui/icons-material/Search';
-import { selectContentViewMode } from '@/selectors';
+import { selectResourceAttribs } from '@/selectors';
 import { useSupportedFilePicker } from '@/modules/model-data';
 import { showError } from '@/modules/error-messages';
 import { useAppDispatch, useAppSelector } from '@/storeTypings';
-import { Box, IconButton } from '@mui/material';
+import { Box } from '@mui/material';
 import { JSX, useCallback } from 'react';
 import GuiPanelButton from './GuiPanelButton';
 import FilesSupportedButton from '../FilesSupportedButton';
@@ -11,50 +10,63 @@ import SearchForFiles from '../SearchForFiles';
 
 export default function FileImportArea() {
   const dispatch = useAppDispatch();
-  const contentViewMode = useAppSelector(selectContentViewMode);
+  const resourceAttribs = useAppSelector(selectResourceAttribs);
   const onHandleError = useCallback((message: string | JSX.Element) => {
     dispatch(showError({ title: 'Invalid file selection', message }));
   }, []);
   const openFileSelector = useSupportedFilePicker(onHandleError);
 
-  // @TODO lay out in more flexibly/auto-adaptably
   return (
     <Box
       className='file-import-area'
-      sx={{
+      sx={({ mixins }) => ({
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center',
+        alignItems: 'stretch',
+        width: '100%',
+        '& .resource-import-controls': {
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'stretch',
+          columnGap: 1,
+          mb: 0,
+          mt: 0
+        },
+        [`@container (min-width: ${mixins.guiPanelExpansionL1W})`]: {
+          '& .resource-import-controls': {
+            flexDirection: 'row'
+          },
+          '& .supported-files': {
+            p: 0,
+            mt: 0,
+            pt: 0
+          }
+        },
+        '& .resource-import-controls > *': {
+          flex: '1 1 0'
+        },
         '& .supported-files': {
           fontSize: '8pt',
-          mt: -1
+          alignSelf: 'stretch'
         },
-        '.panel:not(.welcome).expanded-2 &': {
-          mb: 1
-        },
-        '.panel:not(.welcome).expanded .collapsed-content &': {
-          mb: 0
-        },
-        '.expanded .content & .supported-files, .panel:not(.welcome).expanded & .supported-files':
-          {
-            mt: 0
-          },
         '.content & .supported-files': {
-          width: '100%',
-          mt: -1
+          width: '100%'
         }
-      }}
+      })}
     >
-      <GuiPanelButton
-        id='select-pol-or-tex-button'
-        tooltip='Select MVC2, CVS1, or CVS2 POL.BIN and/or TEX.BIN files'
-        onClick={openFileSelector}
-      >
-        Import Model/Texture
-      </GuiPanelButton>
+      <Box className='resource-import-controls'>
+        <GuiPanelButton
+          id='select-pol-or-tex-button'
+          tooltip='Select MVC2, CVS1, or CVS2 POL.BIN and/or TEX.BIN files'
+          onClick={openFileSelector}
+        >
+          Import Model/Texture
+        </GuiPanelButton>
 
-      <FilesSupportedButton className={'supported-files'} />
-      {contentViewMode !== 'welcome' ? null : <SearchForFiles />}
+        <FilesSupportedButton className={'supported-files'} />
+      </Box>
+
+      <SearchForFiles scope={resourceAttribs} sx={{ my: 0.5 }} />
     </Box>
   );
 }

--- a/src/components/panel/FileImportArea.tsx
+++ b/src/components/panel/FileImportArea.tsx
@@ -1,20 +1,37 @@
-import { selectResourceAttribs } from '@/selectors';
+import { selectContentViewMode, selectResourceAttribs } from '@/selectors';
 import { useSupportedFilePicker } from '@/modules/model-data';
 import { showError } from '@/modules/error-messages';
+import { setObjectViewedIndex } from '@/modules/object-viewer';
 import { useAppDispatch, useAppSelector } from '@/storeTypings';
 import { Box } from '@mui/material';
 import { JSX, useCallback } from 'react';
 import GuiPanelButton from './GuiPanelButton';
 import FilesSupportedButton from '../FilesSupportedButton';
-import SearchForFiles from '../SearchForFiles';
+import ResourceNavigator, {
+  type ResourceNavigatorOption
+} from '../ResourceNavigator';
 
 export default function FileImportArea() {
   const dispatch = useAppDispatch();
+  const contentViewMode = useAppSelector(selectContentViewMode);
   const resourceAttribs = useAppSelector(selectResourceAttribs);
   const onHandleError = useCallback((message: string | JSX.Element) => {
     dispatch(showError({ title: 'Invalid file selection', message }));
   }, []);
   const openFileSelector = useSupportedFilePicker(onHandleError);
+
+  const onSelectResourceNavigatorOption = useCallback(
+    (option: ResourceNavigatorOption) => {
+      if (contentViewMode !== 'polygons' || option.kind !== 'model') {
+        return false;
+      }
+
+      dispatch(setObjectViewedIndex(Number(option.modelIndex)));
+
+      return true;
+    },
+    [contentViewMode, dispatch]
+  );
 
   return (
     <Box
@@ -66,7 +83,17 @@ export default function FileImportArea() {
         <FilesSupportedButton className={'supported-files'} />
       </Box>
 
-      <SearchForFiles scope={resourceAttribs} sx={{ my: 0.5 }} />
+      <ResourceNavigator
+        includeSourceResourceOption={contentViewMode === 'welcome'}
+        label={
+          contentViewMode === 'welcome'
+            ? 'Find supported resources'
+            : 'Find model in resource'
+        }
+        onSelectOption={onSelectResourceNavigatorOption}
+        scope={resourceAttribs}
+        sx={{ my: 0.5 }}
+      />
     </Box>
   );
 }

--- a/src/components/panel/GuiPanel.tsx
+++ b/src/components/panel/GuiPanel.tsx
@@ -181,14 +181,6 @@ export default function GuiPanel() {
           alignItems: 'center',
           justifyContent: 'flex-end'
         },
-        '& .textures': {
-          width: 'calc(100% + (var(--mui-spacing) * 4))',
-          mx: -2,
-          pl: 2,
-          mb: 0,
-          flexGrow: 2,
-          overflowY: 'auto'
-        },
         '& .view-options': {
           display: 'flex',
           flexDirection: 'column',
@@ -198,7 +190,7 @@ export default function GuiPanel() {
         '& .MuiButton-root.MuiButton-outlined': {
           justifyContent: 'center'
         },
-        '& .MuiButton-root.MuiButton-outlined:not(:last-child), &.panel:not(.expanded) .export-texture-button-container:not(:last-child), &.panel:not(.expanded) .export-texture-images:not(:last-child)':
+        '& .MuiButton-root.MuiButton-outlined, &.panel:not(.expanded) .export-texture-button-container:not(:last-child), &.panel:not(.expanded) .export-texture-images:not(:last-child)':
           {
             mb: 1
           },

--- a/src/components/panel/GuiPanelActionButtonRow.tsx
+++ b/src/components/panel/GuiPanelActionButtonRow.tsx
@@ -1,0 +1,22 @@
+import { Box } from '@mui/material';
+import { PropsWithChildren } from 'react';
+
+export default function GuiPanelActionButtonRow({
+  children
+}: PropsWithChildren) {
+  return (
+    <Box
+      sx={(theme) => ({
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'stretch',
+        columnGap: 1,
+        [`@container (max-width: ${theme.mixins.guiPanelExpansionL1W})`]: {
+          flexDirection: 'column'
+        }
+      })}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/src/components/panel/GuiPanelModels.tsx
+++ b/src/components/panel/GuiPanelModels.tsx
@@ -251,7 +251,7 @@ export default function GuiPanelModels() {
             onClick={onOpenGltfExportPopover}
             color='secondary'
           >
-            Export .GLTF
+            Export GLTF
           </GuiPanelButton>
           <Popover
             open={Boolean(gltfExportAnchorEl)}

--- a/src/components/panel/GuiPanelModels.tsx
+++ b/src/components/panel/GuiPanelModels.tsx
@@ -233,6 +233,7 @@ export default function GuiPanelModels() {
           </ToggleButtonGroup>
         </Grid>
       </Grid>
+      <FileImportArea />
       <Box
         sx={{
           display: 'flex',
@@ -241,9 +242,6 @@ export default function GuiPanelModels() {
           columnGap: 1,
           '.panel.expanded &': {
             flexDirection: 'row'
-          },
-          '.panel.expanded & .file-import-area': {
-            flex: '1 0 0'
           },
           '.panel.expanded & .poly-export-buttons': {
             flex: '1 0 0'
@@ -259,7 +257,6 @@ export default function GuiPanelModels() {
           }
         }}
       >
-        <FileImportArea />
         <div className='poly-export-buttons'>
           <GuiPanelButton
             tooltip={

--- a/src/components/panel/GuiPanelModels.tsx
+++ b/src/components/panel/GuiPanelModels.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/modules/object-viewer';
 import SceneOptionsContext from '@/contexts/SceneOptionsContext';
 import FileImportArea from './FileImportArea';
+import GuiPanelActionButtonRow from './GuiPanelActionButtonRow';
 
 export default function GuiPanelModels() {
   const sceneOptions = useContext(SceneOptionsContext);
@@ -239,25 +240,10 @@ export default function GuiPanelModels() {
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'space-between',
-          columnGap: 1,
-          '.panel.expanded &': {
-            flexDirection: 'row'
-          },
-          '.panel.expanded & .poly-export-buttons': {
-            flex: '1 0 0'
-          },
-          '& .poly-export-buttons': {
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'stretch',
-            mb: 1
-          },
-          '& .poly-export-buttons .MuiButton-root': {
-            width: '100%'
-          }
+          columnGap: 1
         }}
       >
-        <div className='poly-export-buttons'>
+        <GuiPanelActionButtonRow>
           <GuiPanelButton
             tooltip={
               'Choose a .gltf export for the current model or all viewable models.'
@@ -271,14 +257,8 @@ export default function GuiPanelModels() {
             open={Boolean(gltfExportAnchorEl)}
             anchorEl={gltfExportAnchorEl}
             onClose={onCloseGltfExportPopover}
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'right'
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'left'
-            }}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
           >
             <Box
               sx={{
@@ -310,7 +290,7 @@ export default function GuiPanelModels() {
             </Box>
           </Popover>
           {exportSelectionButton}
-        </div>
+        </GuiPanelActionButtonRow>
       </Box>
     </GuiPanelSection>
   );

--- a/src/components/panel/GuiPanelSceneOptions.tsx
+++ b/src/components/panel/GuiPanelSceneOptions.tsx
@@ -209,8 +209,7 @@ export default function GuiPanelViewOptions() {
           },
           '& .slider-setting .MuiSlider-root': {
             width: '100%',
-            ml: 0,
-            mr: 0
+            mx: 0.5
           },
           '& .display-mode': {
             display: 'flex',

--- a/src/components/panel/GuiPanelTextures.tsx
+++ b/src/components/panel/GuiPanelTextures.tsx
@@ -22,6 +22,7 @@ import GuiPanelButton from './GuiPanelButton';
 import GuiPanelTexture from './textures/GuiPanelTexture';
 import { Box, Chip, Divider } from '@mui/material';
 import GuiPanelSection from './GuiPanelSection';
+import GuiPanelActionButtonRow from './GuiPanelActionButtonRow';
 
 export default function GuiPanelViewOptions() {
   const dispatch = useAppDispatch();
@@ -171,6 +172,12 @@ export default function GuiPanelViewOptions() {
         sx={{
           display: 'block',
           textAlign: 'left',
+          mb: 0.5,
+          width: 'calc(100% + (var(--mui-spacing) * 4))',
+          mx: -2,
+          pl: 2,
+          flexGrow: 2,
+          overflowY: 'auto',
           '& .MuiDivider-root': {
             my: 2
           }
@@ -188,28 +195,24 @@ export default function GuiPanelViewOptions() {
           </>
         )}
       </Box>
-      <div className='texture-export-options'>
+      <GuiPanelActionButtonRow>
         {!canExportTextures ? undefined : (
-          <div className='export-texture-button-container'>
-            <GuiPanelButton
-              tooltip='Download texture ROM binary with replaced images'
-              onClick={onExportTextureFile}
-              color='primary'
-            >
-              Export Textures
-            </GuiPanelButton>
-          </div>
-        )}
-        <div className='export-texture-images'>
           <GuiPanelButton
-            tooltip='Download all available textures as images in a zip file'
-            onClick={onDownloadAllTextureImgs}
-            color='secondary'
+            tooltip='Download texture ROM binary with replaced images'
+            onClick={onExportTextureFile}
+            color='primary'
           >
-            Download All Images
+            Export Textures
           </GuiPanelButton>
-        </div>
-      </div>
+        )}
+        <GuiPanelButton
+          tooltip='Download all available textures as images in a zip file'
+          onClick={onDownloadAllTextureImgs}
+          color='secondary'
+        >
+          Download All Images
+        </GuiPanelButton>
+      </GuiPanelActionButtonRow>
     </GuiPanelSection>
   );
 }

--- a/src/theming/themes.ts
+++ b/src/theming/themes.ts
@@ -199,6 +199,16 @@ const themes = Object.fromEntries(
       },
       mixins,
       components: {
+        MuiToggleButtonGroup: {
+          styleOverrides: {
+            grouped: {
+              '&.MuiButtonBase-root': {
+                paddingTop: 'calc(var(--mui-spacing) * 0.25)',
+                paddingBottom: 'calc(var(--mui-spacing) * 0.25)'
+              }
+            }
+          }
+        },
         MuiListSubheader: {
           styleOverrides: {
             root: {


### PR DESCRIPTION
Various improvements/iterations on the file searching UX:
- on the welcome panel after a search, the text entry selection will point to the file that contains a resource specifically
- models have the resource navigator embedded
- popover menu for export GLTF options when browsing models v two buttons
- tightened up the layout in the GuiPanel a bit further